### PR TITLE
Use ubi8/openjdk-11 image to clean up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,12 @@
-FROM centos:7
-ARG JAVA_VERSION=11
-
-RUN yum -y update \
-    && yum -y install java-${JAVA_VERSION}-openjdk-headless openssl \
-    && yum -y clean all
-
-#####
-# Add Tini
-#####
-ENV TINI_VERSION v0.18.0
-ENV TINI_SHA256=12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
-RUN echo "${TINI_SHA256} */usr/bin/tini" | sha256sum -c \
-    && chmod +x /usr/bin/tini
-
-RUN useradd -r -m -u 1001 -g 0 user
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.3
 
 ARG kafka_admin_api_version=0.0.6-SNAPSHOT
 ENV KAFKA_ADMIN_API_VERSION ${kafka_admin_api_version}
-ENV KAFKA_ADMIN_HOME=/opt/kafka_admin
-RUN mkdir -p ${KAFKA_ADMIN_HOME}
-WORKDIR ${KAFKA_ADMIN_HOME}
 
-COPY health/target/health-${kafka_admin_api_version}-fat.jar ./
-COPY rest/target/rest-${kafka_admin_api_version}-fat.jar ./
-COPY http-server/target/http-server-${kafka_admin_api_version}-fat.jar ./
-COPY kafka-admin/target/kafka-admin-${kafka_admin_api_version}-fat.jar ./
-COPY docker/run.sh ./
+COPY health/target/health-${kafka_admin_api_version}-fat.jar \
+     rest/target/rest-${kafka_admin_api_version}-fat.jar \
+     http-server/target/http-server-${kafka_admin_api_version}-fat.jar \
+     kafka-admin/target/kafka-admin-${kafka_admin_api_version}-fat.jar \
+     docker/run.sh ./
 
-
-ENTRYPOINT ["/usr/bin/tini", "-w", "-e", "143", "--", "sh", "-c"]
-CMD [ "/opt/kafka_admin/run.sh"]
+CMD [ "./run.sh"]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -9,4 +9,4 @@ do
           ;;
     esac
 done
-java -cp ./kafka-admin-${KAFKA_ADMIN_API_VERSION}-fat.jar:./health-${KAFKA_ADMIN_API_VERSION}-fat.jar:./rest-${KAFKA_ADMIN_API_VERSION}-fat.jar:./http-server-${KAFKA_ADMIN_API_VERSION}-fat.jar bf.admin.Main -XX:+ExitOnOutOfMemoryError
+exec java -cp ./kafka-admin-${KAFKA_ADMIN_API_VERSION}-fat.jar:./health-${KAFKA_ADMIN_API_VERSION}-fat.jar:./rest-${KAFKA_ADMIN_API_VERSION}-fat.jar:./http-server-${KAFKA_ADMIN_API_VERSION}-fat.jar bf.admin.Main -XX:+ExitOnOutOfMemoryError

--- a/systemtests/src/main/java/admin/kafka/systemtest/deployment/AdminDeploymentManager.java
+++ b/systemtests/src/main/java/admin/kafka/systemtest/deployment/AdminDeploymentManager.java
@@ -179,8 +179,11 @@ public class AdminDeploymentManager {
                 .withHostConfig(new HostConfig()
                         .withPublishAllPorts(true)
                         .withNetworkMode(networkName))
-                .withCmd("/opt/kafka_admin/run.sh -e KAFKA_ADMIN_BOOTSTRAP_SERVERS='" + bootstrap
-                        + "' -e KAFKA_ADMIN_OAUTH_ENABLED='" + oauth + "' -e INTERNAL_TOPICS_ENABLED='" + internal + "' -e REPLICATION_FACTOR='1'").exec();
+                .withCmd("/home/jboss/run.sh",
+                     "-e", String.format("KAFKA_ADMIN_BOOTSTRAP_SERVERS=%s", bootstrap),
+                     "-e", String.format("KAFKA_ADMIN_OAUTH_ENABLED=%s", oauth),
+                     "-e", String.format("INTERNAL_TOPICS_ENABLED=%s", internal),
+                     "-e", "REPLICATION_FACTOR=1").exec();
         String adminContId = contResp.getId();
         client.startContainerCmd(contResp.getId()).exec();
         int adminPublishedPort = Integer.parseInt(client.inspectContainerCmd(contResp.getId()).exec().getNetworkSettings()


### PR DESCRIPTION
There are several Dockerfile changes here:

- The container process is running as jboss user rather than root
- Tini is no longer being used
- Everything is copied into the default location (/home/jboss)
- Reduced layers by using a single COPY instruction
- EL8 base image, already containing openjdk

There's also a change to the run.sh script: it now runs `exec java`
rather than `java` -- this means that the run.sh process exits at this
point, and the java process is the main process in the container.

The run time effect of these changes is that there's one non-root
process running (java), rather than 3 root processes (tini, sh,
java).
