### PR TITLE
Allow rest specs to work with a local SwaggerUI

### DIFF
--- a/rest/src/main/resources/openapi-specs/rest.yaml
+++ b/rest/src/main/resources/openapi-specs/rest.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Kafka Admon REST API
+  title: Kafka Admin REST API
   version: 0.1.0
   description: An API to provide REST endpoints for query Kafka for admin operations
   license:
@@ -18,6 +18,9 @@ servers:
     description: localhost
   -
     url: 'http://localhost:8000'
+    description: localhost
+  -
+    url: 'http://localhost:8080/rest'
     description: localhost
 paths:
   /topics:
@@ -81,7 +84,6 @@ paths:
                   name: my-topic
                   settings:
                     numPartitions: 3
-                    replicationFactor: 4
                     config:
                       -
                         key: min.insync.replicas


### PR DESCRIPTION
I don't know how the other localhost entries in the server list are
used, but to be able to interact using a locally running SwaggerUI
interface, I needed to add this new one.

I also removed the `replicationFactor` field from the create topic
example, as the following error is returned if it's there:

```
{
  "code": 400,
  "error": "Unrecognized field \"replicationFactor\" (class admin.kafka.admin.model.Types$NewTopicInput), not marked as ignorable (2 known properties: \"config\", \"numPartitions\"])\n at [Source: (byte[])\"{\n  \"name\": \"my-topic2\",\n  \"settings\": {\n    \"numPartitions\": 3,\n    \"replicationFactor\": 4,\n    \"config\": [\n      {\n        \"key\": \"min.insync.replicas\",\n        \"value\": \"1\"\n      },\n      {\n        \"key\": \"max.message.bytes\",\n        \"value\": \"1050000\"\n      }\n    ]\n  }\n}\"; line: 5, column: 27] (through reference chain: admin.kafka.admin.model.Types$NewTopic[\"settings\"]->admin.kafka.admin.model.Types$NewTopicInput[\"replicationFactor\"])"
}
```