### PR TITLE
Don't expose consumer group /reset-offset

### DIFF
--- a/rest/src/main/java/org/bf2/admin/rest/RestService.java
+++ b/rest/src/main/java/org/bf2/admin/rest/RestService.java
@@ -62,7 +62,6 @@ public class RestService implements RouteRegistration {
         routerFactory.operation(Operations.GET_CONSUMER_GROUPS_LIST).handler(ro.listGroups(kaConfig, vertx, httpMetrics)).failureHandler(ro.errorHandler(httpMetrics));
 
         routerFactory.operation(Operations.DELETE_CONSUMER_GROUP).handler(ro.deleteGroup(kaConfig, vertx, httpMetrics)).failureHandler(ro.errorHandler(httpMetrics));
-        routerFactory.operation(Operations.RESET_CONSUMER_GROUP_OFFSET).handler(ro.resetGroupOffset(kaConfig, vertx, httpMetrics)).failureHandler(ro.errorHandler(httpMetrics));
 
         routerFactory.operation(Operations.OPEN_API).handler(ro.openApi(vertx, httpMetrics)).failureHandler(ro.errorHandler(httpMetrics));
 

--- a/rest/src/main/resources/openapi-specs/rest.yaml
+++ b/rest/src/main/resources/openapi-specs/rest.yaml
@@ -359,43 +359,6 @@ paths:
           type: string
         in: path
         required: true
-  '/consumer-groups/{consumerGroupId}/reset-offset':
-    post:
-      parameters:
-        - name: consumerGroupId
-          description: The ID of the consumer group.
-          schema:
-            type: string
-          in: path
-          required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConsumerGroup'
-          description: The consumer group offsets have been reset.
-        '401':
-          content:
-            application/json: {}
-          description: >-
-            Unauthorized, request has not been applied because it lacks valid authentication
-            credentials.
-        '403':
-          content:
-            application/json: {}
-          description: Forbidden to delete this consumer group.
-        '500':
-          content:
-            application/json: {}
-          description: Internal Server Error.
-        '503':
-          content:
-            application/json: {}
-          description: Unable to connect to the Kafka cluster.
-      operationId: resetConsumerGroupOffset
-      summary: Reset the offset for a consumer group.
-      description: Reset the offset for a particular consumer group.
   /consumer-groups:
     summary: API endpoints for consumer groups under a Kafka topic
     get:


### PR DESCRIPTION
The current implementation is not how it will eventually be, so this
is just to allow us to make a new release without having to worry
about someone relying on it.