### PR TITLE
Prepare release 0.0.6

### DIFF
--- a/.run/Main (EnvFile).run.xml
+++ b/.run/Main (EnvFile).run.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="org.bf2.admin.Main" />
     <module name="http-server" />
     <option name="PROGRAM_PARAMETERS" value="org.bf2.admin.Main" />
-    <option name="VM_PARAMETERS" value="-cp kafka-admin/target/kafka-admin-0.0.6-fat.jar:health/target/health-0.0.6-fat.jar:rest/target/rest-0.0.6-fat.jar:http-server/target/http-server-0.0.6-fat.jar org.bf2.admin.Main" />
+    <option name="VM_PARAMETERS" value="-cp kafka-admin/target/kafka-admin-0.0.7-SNAPSHOT-fat.jar:health/target/health-0.0.7-SNAPSHOT-fat.jar:rest/target/rest-0.0.7-SNAPSHOT-fat.jar:http-server/target/http-server-0.0.7-SNAPSHOT-fat.jar org.bf2.admin.Main" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="true" />
       <option name="IS_SUBST" value="false" />

--- a/.run/Main.run.xml
+++ b/.run/Main.run.xml
@@ -9,7 +9,7 @@
     <option name="MAIN_CLASS_NAME" value="org.bf2.admin.Main" />
     <module name="http-server" />
     <option name="PROGRAM_PARAMETERS" value="org.bf2.admin.Main" />
-    <option name="VM_PARAMETERS" value="-cp kafka-admin/target/kafka-admin-0.0.6-fat.jar:health/target/health-0.0.6-fat.jar:rest/target/rest-0.0.6-fat.jar:http-server/target/http-server-0.0.6-fat.jar org.bf2.admin.Main" />
+    <option name="VM_PARAMETERS" value="-cp kafka-admin/target/kafka-admin-0.0.7-SNAPSHOT-fat.jar:health/target/health-0.0.7-SNAPSHOT-fat.jar:rest/target/rest-0.0.7-SNAPSHOT-fat.jar:http-server/target/http-server-0.0.7-SNAPSHOT-fat.jar org.bf2.admin.Main" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />
       <option name="IS_SUBST" value="false" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/openjdk-11:1.3
 
-ARG kafka_admin_api_version=0.0.6
+ARG kafka_admin_api_version=0.0.7-SNAPSHOT
 ENV KAFKA_ADMIN_API_VERSION ${kafka_admin_api_version}
 
 COPY health/target/health-${kafka_admin_api_version}-fat.jar \

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kafka-admin-api</artifactId>
         <groupId>org.bf2</groupId>
-        <version>0.0.6</version>
+        <version>0.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kafka-admin-api</artifactId>
         <groupId>org.bf2</groupId>
-        <version>0.0.6</version>
+        <version>0.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-admin/pom.xml
+++ b/kafka-admin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kafka-admin-api</artifactId>
         <groupId>org.bf2</groupId>
-        <version>0.0.6</version>
+        <version>0.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.bf2</groupId>
     <artifactId>kafka-admin-api</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.6</version>
+    <version>0.0.7-SNAPSHOT</version>
 
     <modules>
         <module>http-server</module>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kafka-admin-api</artifactId>
         <groupId>org.bf2</groupId>
-        <version>0.0.6</version>
+        <version>0.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.bf2</groupId>
             <artifactId>kafka-admin</artifactId>
-            <version>0.0.6</version>
+            <version>0.0.7-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.bf2</groupId>
         <artifactId>kafka-admin-api</artifactId>
-        <version>0.0.6</version>
+        <version>0.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>systemtests</artifactId>


### PR DESCRIPTION
Commit 8500f48 was used to build image `quay.io/grdryn/kafka-admin-api:0.0.6`.

@k-wall do you have the ability to copy that image to `quay.io/mk-ci-cd/kafka-admin-api:0.0.6`?