### PR TITLE
Respond to consumer-group list with expected shape

### DIFF
--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/ConsumerGroupOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/ConsumerGroupOperations.java
@@ -93,7 +93,14 @@ public class ConsumerGroupOperations {
                 }
 
                 List<Types.ConsumerGroupDescription> croppedList = list.subList(offset, Math.min(offset + tmpLimit, list.size()));
-                return Future.succeededFuture(croppedList);
+
+                Types.ConsumerGroupList response = new Types.ConsumerGroupList();
+                response.setItems(croppedList);
+                response.setCount(croppedList.size());
+                response.setLimit(tmpLimit);
+                response.setOffset(offset);
+
+                return Future.succeededFuture(response);
             })
             .onComplete(finalRes -> {
                 if (finalRes.failed()) {

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/TopicOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/TopicOperations.java
@@ -143,7 +143,7 @@ public class TopicOperations {
                     topicWithDescription.setConfig(getTopicConf(cfg));
                     fullTopicDescriptions.add(topicWithDescription);
                 });
-                Types.TopicList topicList = new Types.TopicList();
+
                 if (sortDirection.equals(Types.SortDirectionEnum.ASC)) {
                     fullTopicDescriptions.sort(new CommonHandler.TopicComparator());
                 } else {
@@ -159,6 +159,8 @@ public class TopicOperations {
                 }
 
                 List<Types.Topic> croppedList = fullTopicDescriptions.subList(offset, Math.min(offset + tmpLimit, fullTopicDescriptions.size()));
+
+                Types.TopicList topicList = new Types.TopicList();
                 topicList.setItems(croppedList);
                 topicList.setCount(croppedList.size());
                 topicList.setLimit(tmpLimit);

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/model/Types.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/model/Types.java
@@ -305,6 +305,7 @@ public class Types {
 
     public static class ConsumerGroupDescription extends ConsumerGroup {
         private List<Consumer> consumers;
+        private String state;
 
         public List<Consumer> getConsumers() {
             return consumers;
@@ -321,8 +322,38 @@ public class Types {
         public void setState(String state) {
             this.state = state;
         }
+    }
 
-        private String state;
+    public static class ConsumerGroupList {
+        private List<ConsumerGroupDescription> items;
+        private Integer offset;
+        private Integer limit;
+        private Integer count;
+
+        public List<ConsumerGroupDescription> getItems() {
+            return items;
+        }
+        public void setItems(List<ConsumerGroupDescription> items) {
+            this.items = items;
+        }
+        public Integer getOffset() {
+            return offset;
+        }
+        public void setOffset(Integer offset) {
+            this.offset = offset;
+        }
+        public Integer getLimit() {
+            return limit;
+        }
+        public void setLimit(Integer limit) {
+            this.limit = limit;
+        }
+        public Integer getCount() {
+            return count;
+        }
+        public void setCount(Integer count) {
+            this.count = count;
+        }
     }
 
     public static class Consumer {


### PR DESCRIPTION
Before this change, a list of consumer group descriptions was
returned, where the API spec actually expects it to be an object,
where that list is the value of the "items" key.