### PR TITLE
Hide consumer groups that have "strimzi" prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,6 @@ Once all steps above have been completed, you can run the Kafka Admin API. The s
 | KAFKA_ADMIN_BOOTSTRAP_SERVERS | A comma-separated list of host and port pairs that are the addresses of the Kafka brokers in a "bootstrap" Kafka cluster.   |
 | KAFKA_ADMIN_OAUTH_ENABLED | Enables a third party application to obtain limited access to the Admin API. |
 | KAFKA_ADMIN_INTERNAL_TOPICS_ENABLED | Internal topics are used internally by the Kafka Streams application while executing. |
+| KAFKA_ADMIN_INTERNAL_CONSUMER_GROUPS_ENABLED | Internal consumer groups are used internally by the Strimzi Canary application. |
 | KAFKA_ADMIN_REPLICATION_FACTOR | Replication factor defines the number of copies of a topic in a Kafka cluster. |
 | KAFKA_ADMIN_NUM_PARTITIONS_MAX | Maximum (inclusive) number of partitions that may be used for the creation of a new topic. |

--- a/docker/deployment.yaml
+++ b/docker/deployment.yaml
@@ -27,6 +27,8 @@ spec:
               value: "false"
             - name: KAFKA_ADMIN_INTERNAL_TOPICS_ENABLED
               value: "false"
+            - name: KAFKA_ADMIN_INTERNAL_CONSUMER_GROUPS_ENABLED
+              value: "false"
             - name: REST_LOG_LEVEL
               value: "INFO"
           resources:


### PR DESCRIPTION
The initial reason for this is so that the strimzi canary group isn't
shown to users.