### PR TITLE
Apply `status_code` label to `failed_requests` counter

### DIFF
--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/HttpMetrics.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/HttpMetrics.java
@@ -6,10 +6,12 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.vertx.micrometer.backends.BackendRegistries;
 
 public class HttpMetrics {
+    private static final String FAILED_REQUESTS_COUNTER = "failed_requests";
+    private static final String HTTP_STATUS_CODE = "status_code";
+
     private PrometheusMeterRegistry meterRegistry;
     private Counter requestsCounter;
     private Counter openApiCounter;
-    private Counter failedRequestsCounter;
     private Counter succeededRequestsCounter;
     private Counter deleteTopicCounter;
     private Counter createTopicCounter;
@@ -41,7 +43,10 @@ public class HttpMetrics {
     private void init() {
         requestsCounter = meterRegistry.counter("requests");
         openApiCounter = meterRegistry.counter("requests_openapi");
-        failedRequestsCounter = meterRegistry.counter("failed_requests");
+        /*
+         * Status code 404 is a placeholder for defining the status_code label.
+         */
+        meterRegistry.counter(FAILED_REQUESTS_COUNTER, HTTP_STATUS_CODE, "404");
         succeededRequestsCounter = meterRegistry.counter("succeeded_requests");
         deleteTopicCounter = meterRegistry.counter("delete_topic_requests");
         createTopicCounter = meterRegistry.counter("create_topic_requests");
@@ -70,8 +75,8 @@ public class HttpMetrics {
         return meterRegistry;
     }
 
-    public Counter getFailedRequestsCounter() {
-        return failedRequestsCounter;
+    public Counter getFailedRequestsCounter(int httpStatusCode) {
+        return getRegistry().counter(FAILED_REQUESTS_COUNTER, HTTP_STATUS_CODE, String.valueOf(httpStatusCode));
     }
 
     public Counter getRequestsCounter() {

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/CommonHandler.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/CommonHandler.java
@@ -139,7 +139,7 @@ public class CommonHandler {
                     jo.put("class", res.cause().getClass().getSimpleName());
                 }
                 routingContext.response().end(jo.toBuffer());
-                httpMetrics.getFailedRequestsCounter().increment();
+                httpMetrics.getFailedRequestsCounter(routingContext.response().getStatusCode()).increment();
                 requestTimerSample.stop(timer);
                 log.error("{} {}", res.cause().getClass(), res.cause().getMessage());
             } else {
@@ -153,7 +153,7 @@ public class CommonHandler {
                     jsonObject.put("code", routingContext.response().getStatusCode());
                     jsonObject.put("error", e.getMessage());
                     routingContext.response().end(jsonObject.toBuffer());
-                    httpMetrics.getFailedRequestsCounter().increment();
+                    httpMetrics.getFailedRequestsCounter(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()).increment();
                     requestTimerSample.stop(timer);
                     log.error(e);
                     return;

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RestOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RestOperations.java
@@ -54,7 +54,7 @@ public class RestOperations extends CommonHandler implements OperationsHandler<H
                     routingContext.response().end(jsonObject.toBuffer());
                     log.error(e);
                     prom.fail(e);
-                    httpMetrics.getFailedRequestsCounter().increment();
+                    httpMetrics.getFailedRequestsCounter(HttpResponseStatus.BAD_REQUEST.code()).increment();
                     requestTimerSample.stop(httpMetrics.getCreateTopicRequestTimer());
                     return;
                 }
@@ -151,7 +151,7 @@ public class RestOperations extends CommonHandler implements OperationsHandler<H
                         jsonObject.put("error", e.getMessage());
                         routingContext.response().end(jsonObject.toBuffer());
                         requestTimerSample.stop(httpMetrics.getUpdateTopicRequestTimer());
-                        httpMetrics.getFailedRequestsCounter().increment();
+                        httpMetrics.getFailedRequestsCounter(HttpResponseStatus.BAD_REQUEST.code()).increment();
                         prom.fail(e);
                         log.error(e);
                         return;

--- a/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/plain/MetricsEndpointTestIT.java
+++ b/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/plain/MetricsEndpointTestIT.java
@@ -145,14 +145,17 @@ public class MetricsEndpointTestIT extends PlainTestBase {
         RequestUtils.prepareAndExecuteFailDeleteRequest(testContext, 5, client, publishedAdminPort);
         RequestUtils.prepareAndExecuteDeleteRequest(testContext, 3, client, kafkaClient, publishedAdminPort);
         RequestUtils.prepareAndExecuteListRequest(testContext, 2, client, publishedAdminPort);
+        RequestUtils.prepareAndExecuteFailCreateTopicRequest(testContext, 4, client, publishedAdminPort);
 
         String metrics =  RequestUtils.retrieveMetrics(testContext, client, publishedAdminPort);
         Pattern patternTotal = Pattern.compile("^requests_total ([0-9.]+)", Pattern.MULTILINE);
-        Pattern patternFailed = Pattern.compile("^failed_requests_total ([0-9.]+)", Pattern.MULTILINE);
+        Pattern patternFailedNotFound = Pattern.compile("^failed_requests_total\\{status_code=\"404\",\\} ([0-9.]+)", Pattern.MULTILINE);
+        Pattern patternFailedBadRequest = Pattern.compile("^failed_requests_total\\{status_code=\"400\",\\} ([0-9.]+)", Pattern.MULTILINE);
         Pattern patternSucc = Pattern.compile("^succeeded_requests_total ([0-9.]+)", Pattern.MULTILINE);
         HashMap<Matcher, String> matchers = new HashMap<Matcher, String>() {{
-                put(patternTotal.matcher(metrics), "10.0");
-                put(patternFailed.matcher(metrics), "5.0");
+                put(patternTotal.matcher(metrics), "14.0");
+                put(patternFailedNotFound.matcher(metrics), "5.0");
+                put(patternFailedBadRequest.matcher(metrics), "4.0");
                 put(patternSucc.matcher(metrics), "5.0");
             }};
 


### PR DESCRIPTION
* Add `status_code` label to `failed_requests` metric
* Modify existing metrics test to include additional failure status code
* Add test to validate status code `401` properly incremented when `Authorization` head missing and OAuth is active

CC: @ppatierno 