### PR TITLE
Fail unauthenticated requests w/o attempting to create `KafkaAdminClient`

### DIFF
--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/KafkaAdminConfigRetriever.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/KafkaAdminConfigRetriever.java
@@ -18,6 +18,7 @@ public class KafkaAdminConfigRetriever {
 
     protected final Logger log = LogManager.getLogger(KafkaAdminConfigRetriever.class);
     private static final String PREFIX = "KAFKA_ADMIN_";
+    private static final String OAUTHBEARER = "OAUTHBEARER";
     private static Map<String, Object> config;
 
     public KafkaAdminConfigRetriever() throws Exception {
@@ -25,10 +26,10 @@ public class KafkaAdminConfigRetriever {
         logConfiguration();
     }
 
-    private Map envVarsToAdminClientConfig(String prefix) throws Exception {
-        Map envConfig = System.getenv().entrySet().stream().filter(entry -> entry.getKey().startsWith(prefix)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    private Map<String, Object> envVarsToAdminClientConfig(String prefix) throws Exception {
+        Map<String, Object> envConfig = System.getenv().entrySet().stream().filter(entry -> entry.getKey().startsWith(prefix)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        Map<String, String> adminClientConfig = new HashMap();
+        Map<String, Object> adminClientConfig = new HashMap<>();
         if (envConfig.get(PREFIX + "BOOTSTRAP_SERVERS") == null) {
             throw new Exception("Bootstrap address has to be specified");
         }
@@ -38,7 +39,7 @@ public class KafkaAdminConfigRetriever {
         if (System.getenv(PREFIX + "OAUTH_ENABLED") == null ? true : Boolean.valueOf(System.getenv(PREFIX + "OAUTH_ENABLED"))) {
             log.info("oAuth enabled");
             adminClientConfig.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
-            adminClientConfig.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
+            adminClientConfig.put(SaslConfigs.SASL_MECHANISM, OAUTHBEARER);
             adminClientConfig.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
         } else {
             log.info("oAuth disabled");
@@ -58,8 +59,12 @@ public class KafkaAdminConfigRetriever {
         });
     }
 
-    public Map getAcConfig() {
-        return new HashMap(config);
+    public static boolean isOauthEnabled(Map<String, Object> config) {
+        return OAUTHBEARER.equals(config.get(SaslConfigs.SASL_MECHANISM));
+    }
+
+    public Map<String, Object> getAcConfig() {
+        return new HashMap<>(config);
     }
 }
 

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RestOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RestOperations.java
@@ -39,7 +39,9 @@ public class RestOperations extends CommonHandler implements OperationsHandler<H
             httpMetrics.getCreateTopicCounter().increment();
             httpMetrics.getRequestsCounter().increment();
             Timer.Sample requestTimerSample = Timer.start(httpMetrics.getRegistry());
-            setOAuthToken(acConfig, routingContext);
+            if (!setOAuthToken(acConfig, routingContext)) {
+                return;
+            }
             createAdminClient(vertx, acConfig).onComplete(ac -> {
                 Types.NewTopic inputTopic = new Types.NewTopic();
                 Promise<Types.NewTopic> prom = Promise.promise();
@@ -90,7 +92,9 @@ public class RestOperations extends CommonHandler implements OperationsHandler<H
             httpMetrics.getDescribeTopicCounter().increment();
             httpMetrics.getRequestsCounter().increment();
             Timer.Sample requestTimerSample = Timer.start(httpMetrics.getRegistry());
-            setOAuthToken(acConfig, routingContext);
+            if (!setOAuthToken(acConfig, routingContext)) {
+                return;
+            }
             String topicToDescribe = routingContext.pathParam("topicName");
             Promise<Types.Topic> prom = Promise.promise();
             if (topicToDescribe == null || topicToDescribe.isEmpty()) {
@@ -122,7 +126,9 @@ public class RestOperations extends CommonHandler implements OperationsHandler<H
             httpMetrics.getUpdateTopicCounter().increment();
             httpMetrics.getRequestsCounter().increment();
             Timer.Sample requestTimerSample = Timer.start(httpMetrics.getRegistry());
-            setOAuthToken(acConfig, routingContext);
+            if (!setOAuthToken(acConfig, routingContext)) {
+                return;
+            }
             Promise<Types.UpdatedTopic> prom = Promise.promise();
             String topicToUpdate = routingContext.pathParam("topicName");
             if (topicToUpdate == null || topicToUpdate.isEmpty()) {
@@ -172,7 +178,9 @@ public class RestOperations extends CommonHandler implements OperationsHandler<H
             httpMetrics.getDeleteTopicCounter().increment();
             httpMetrics.getRequestsCounter().increment();
             Timer.Sample requestTimerSample = Timer.start(httpMetrics.getRegistry());
-            setOAuthToken(acConfig, routingContext);
+            if (!setOAuthToken(acConfig, routingContext)) {
+                return;
+            }
             String topicToDelete = routingContext.pathParam("topicName");
             Promise<List<String>> prom = Promise.promise();
             if (topicToDelete == null || topicToDelete.isEmpty()) {
@@ -205,7 +213,9 @@ public class RestOperations extends CommonHandler implements OperationsHandler<H
             Timer.Sample requestTimerSample = Timer.start(httpMetrics.getRegistry());
             httpMetrics.getListTopicsCounter().increment();
             httpMetrics.getRequestsCounter().increment();
-            setOAuthToken(acConfig, routingContext);
+            if (!setOAuthToken(acConfig, routingContext)) {
+                return;
+            }
             String filter = routingContext.queryParams().get("filter");
             String limit = routingContext.queryParams().get("limit") == null ? "0" : routingContext.queryParams().get("limit");
             String offset = routingContext.queryParams().get("offset") == null ? "0" : routingContext.queryParams().get("offset");
@@ -245,7 +255,9 @@ public class RestOperations extends CommonHandler implements OperationsHandler<H
             Timer.Sample requestTimerSample = Timer.start(httpMetrics.getRegistry());
             httpMetrics.getListGroupsCounter().increment();
             httpMetrics.getRequestsCounter().increment();
-            setOAuthToken(acConfig, routingContext);
+            if (!setOAuthToken(acConfig, routingContext)) {
+                return;
+            }
             String topicFilter = routingContext.queryParams().get("topic");
             String limit = routingContext.queryParams().get("limit") == null ? "0" : routingContext.queryParams().get("limit");
             String offset = routingContext.queryParams().get("offset") == null ? "0" : routingContext.queryParams().get("offset");
@@ -283,7 +295,9 @@ public class RestOperations extends CommonHandler implements OperationsHandler<H
             httpMetrics.getDescribeGroupCounter().increment();
             httpMetrics.getRequestsCounter().increment();
             Timer.Sample requestTimerSample = Timer.start(httpMetrics.getRegistry());
-            setOAuthToken(acConfig, routingContext);
+            if (!setOAuthToken(acConfig, routingContext)) {
+                return;
+            }
             String groupToDescribe = routingContext.pathParam("consumerGroupId");
             Promise<Types.Topic> prom = Promise.promise();
             if (!internalGroupsAllowed() && groupToDescribe.startsWith("strimzi")) {
@@ -314,7 +328,9 @@ public class RestOperations extends CommonHandler implements OperationsHandler<H
             httpMetrics.getDeleteGroupCounter().increment();
             httpMetrics.getRequestsCounter().increment();
             Timer.Sample requestTimerSample = Timer.start(httpMetrics.getRegistry());
-            setOAuthToken(acConfig, routingContext);
+            if (!setOAuthToken(acConfig, routingContext)) {
+                return;
+            }
             String groupToDelete = routingContext.pathParam("consumerGroupId");
             Promise<List<String>> prom = Promise.promise();
             if (!internalGroupsAllowed() && groupToDelete.startsWith("strimzi")) {
@@ -346,7 +362,9 @@ public class RestOperations extends CommonHandler implements OperationsHandler<H
             httpMetrics.getRequestsCounter().increment();
             httpMetrics.getRequestsCounter().increment();
             Timer.Sample requestTimerSample = Timer.start(httpMetrics.getRegistry());
-            setOAuthToken(acConfig, routingContext);
+            if (!setOAuthToken(acConfig, routingContext)) {
+                return;
+            }
             String groupToReset = routingContext.pathParam("consumerGroupId");
 
             Promise<List<String>> prom = Promise.promise();


### PR DESCRIPTION
This change is transparent to the client, hence no changes to tests.

CC: @ppatierno , @k-wall , @sknot-rh , @obabec 