### PR TITLE
WIP: Track proper expectation for hacked test

### DIFF
--- a/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/oauth/ConsumerGroupsOAuthTestIT.java
+++ b/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/oauth/ConsumerGroupsOAuthTestIT.java
@@ -52,7 +52,7 @@ public class ConsumerGroupsOAuthTestIT extends OauthTestBase {
         client.request(HttpMethod.GET, publishedAdminPort, "localhost", "/rest/consumer-groups")
                 .compose(req -> req.putHeader("Authorization", "Bearer " + token.getAccessToken()).send()
                         .onSuccess(response -> testContext.verify(() -> {
-                            assertThat(response.statusCode()).isEqualTo(ReturnCodes.SUCCESS.code);
+                            assertThat(response.statusCode()).isEqualTo(ReturnCodes.FORBIDDEN.code);
                             testContext.completeNow();
                         })));
         assertThat(testContext.awaitCompletion(1, TimeUnit.MINUTES)).isTrue();


### PR DESCRIPTION
This test was originally proposed in #33, but #39 updated it to expect
a 200 http status code, to allow it to pass. This change exists to
figure out and discuss if we can (and/or should) get a 4xx rather than
a 200.

We expect a 401 from `GET /consumer-groups` if an unauthorized token
is used, but the server doesn't seem to get any exception information
from the KafkaAdminClient to indicate that the user is not
authorized, so the response is indistinguishable from that of an
authorized user querying for a list of consumer groups when there
aren't any.

This appears to be different from `GET /topics`, where the equivalent
KafkaAdminClient invocations _do_ seem to get enough exception
information to indicate that it's an unauthorized token.

It's also different from `GET /consumer-groups` with an _invalid_
rather than _unauthorized_ token, as an invalid token _does_ get an
Exception from the KafkaAdminClient.