### PR TITLE
chore(openapi): change property to match what is returned from the API

### DIFF
--- a/rest/src/main/resources/openapi-specs/rest.yaml
+++ b/rest/src/main/resources/openapi-specs/rest.yaml
@@ -248,7 +248,7 @@ paths:
         - examples:
             Consumer group:
               value:
-                id: consumer_group_1
+                groupId: consumer_group_1
                 consumers:
                   - groupId: consumer_group_1
                     topic: topic-1
@@ -391,7 +391,7 @@ paths:
                     limit: 10
                     offset: 0
                     items:
-                      - id: consumer_group_1
+                      - groupId: consumer_group_1
                         consumers:
                           - groupId: consumer_group_1
                             topic: topic-1
@@ -641,11 +641,11 @@ components:
     ConsumerGroup:
       description: A group of Kafka consumers
       required:
-        - id
+        - groupId
         - consumers
       type: object
       properties:
-        id:
+        groupId:
           description: Unique identifier for the consumer group
           type: string
         consumers:
@@ -750,7 +750,7 @@ components:
         limit: 10
         offset: 0
         items:
-          - id: consumer_group_1
+          - groupId: consumer_group_1
             consumers:
               - groupId: consumer_group_1
                 topic: topic-1


### PR DESCRIPTION
The API returned a different value to the OpenAPI specification.

I think in the future we should add some kind of contract tests, to ensure the API inputs and outputs always match what the OpenAPI expects.