### PR TITLE
feat(consumergroup): add the ability to filter consumer groups by their ID

### DIFF
--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/ConsumerGroupOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/ConsumerGroupOperations.java
@@ -32,7 +32,7 @@ public class ConsumerGroupOperations {
     protected static final Logger log = LogManager.getLogger(ConsumerGroupOperations.class);
 
 
-    public static void getGroupList(KafkaAdminClient ac, Promise prom, Pattern pattern, int offset, final int limit) {
+    public static void getGroupList(KafkaAdminClient ac, Promise prom, Pattern pattern, int offset, final int limit, final String groupIdPrefix) {
         Promise<List<ConsumerGroupListing>> listConsumerGroupsFuture = Promise.promise();
 
         ac.listConsumerGroups(listConsumerGroupsFuture);
@@ -43,6 +43,7 @@ public class ConsumerGroupOperations {
 
                 List<String> groupIds = list.stream().map(group -> group.getGroupId())
                         .filter(groupId -> !internalGroupsAllowed ? !groupId.startsWith("strimzi") : true)
+                        .filter(groupId -> groupId.startsWith(groupIdPrefix))
                         .collect(Collectors.toList());
                 Promise<Map<String, ConsumerGroupDescription>> describeConsumerGroupsPromise = Promise.promise();
                 ac.describeConsumerGroups(groupIds, describeConsumerGroupsPromise);

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RestOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RestOperations.java
@@ -260,6 +260,7 @@ public class RestOperations extends CommonHandler implements OperationsHandler {
             return;
         }
         String topicFilter = routingContext.queryParams().get("topic");
+        String consumerGroupIdFilter = routingContext.queryParams().get("group-id-filter") == null ? "" : routingContext.queryParams().get("group-id-filter");
         String limit = routingContext.queryParams().get("limit") == null ? "0" : routingContext.queryParams().get("limit");
         String offset = routingContext.queryParams().get("offset") == null ? "0" : routingContext.queryParams().get("offset");
         final Pattern pattern;
@@ -278,7 +279,7 @@ public class RestOperations extends CommonHandler implements OperationsHandler {
                     if (Integer.parseInt(offset) < 0 || Integer.parseInt(limit) < 0) {
                         throw new InvalidRequestException("Offset and limit have to be positive integers.");
                     }
-                    ConsumerGroupOperations.getGroupList(ac.result(), prom, pattern, Integer.parseInt(offset), Integer.parseInt(limit));
+                    ConsumerGroupOperations.getGroupList(ac.result(), prom, pattern, Integer.parseInt(offset), Integer.parseInt(limit), consumerGroupIdFilter);
                 } catch (NumberFormatException | InvalidRequestException e) {
                     prom.fail(e);
                     processResponse(prom, routingContext, HttpResponseStatus.BAD_REQUEST, httpMetrics, httpMetrics.getListGroupsRequestTimer(), requestTimerSample);

--- a/kafka-admin/src/main/resources/openapi-specs/rest.yaml
+++ b/kafka-admin/src/main/resources/openapi-specs/rest.yaml
@@ -30,7 +30,7 @@ paths:
             type: string
           in: query
         - name: offset
-          description: The page offset when returning  the limit of requested topics.
+          description: The page offset when returning the limit of requested topics.
           schema:
             format: int32
             type: integer
@@ -357,7 +357,12 @@ paths:
             type: integer
           in: query
         - name: topic
-          description: Filter to apply when returning the list of consumer groups
+          description: Return consumer groups for this topic
+          schema:
+            type: string
+          in: query
+        - name: group-id-filter
+          description: Return the consumer groups where the ID begins with this value
           schema:
             type: string
           in: query


### PR DESCRIPTION
This PR adds the ability to filter a subset of consumer groups by their ID. The filter returns all consumer groups with an ID that starts with the passed filter value.

`filter` is probably not a perfect query parameter name as it is very generic and could mean anything. It is consistent with the filter param on the topic endpoint though. Open to name change suggestions :)

### Verification

Make a call to the listConsumerGroups endpoint: `http://localhost:8080/rest/consumer-groups?group-id-prefix={your-prefix}`