### PR TITLE
Only complete promise if not already completed

### DIFF
--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/ConsumerGroupOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/ConsumerGroupOperations.java
@@ -193,8 +193,9 @@ public class ConsumerGroupOperations {
                     Types.ConsumerGroupDescription groupDescription = getConsumerGroupsDescription(Pattern.compile(".*"), cgDescriptions, cgOffsets, endOffsets).get(0);
                     if ("dead".equalsIgnoreCase(groupDescription.getState())) {
                         prom.fail(new GroupIdNotFoundException("Group " + groupDescription.getGroupId() + " does not exist"));
+                    } else {
+                        prom.complete(groupDescription);
                     }
-                    prom.complete(groupDescription);
                 }
                 ac.close();
             });


### PR DESCRIPTION
This should address the following exception:

```
2021-04-19 15:50:45 ERROR CommonHandler:147 - class org.apache.kafka.common.errors.GroupIdNotFoundException Group f0ae1607-16c8-46b8-b8a4-65b95a2375a2 does not exist
2021-04-19 15:50:45 ERROR ContextImpl: - Unhandled exception
java.lang.IllegalStateException: Result is already complete
	at io.vertx.core.Promise.complete(Promise.java:67) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at org.bf2.admin.kafka.admin.ConsumerGroupOperations.lambda$describeGroup$22(ConsumerGroupOperations.java:197) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl$3.onSuccess(FutureImpl.java:124) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:62) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:179) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.Composition$1.onSuccess(Composition.java:62) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:62) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:179) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.CompositeFutureImpl.complete(CompositeFutureImpl.java:172) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.CompositeFutureImpl.lambda$join$3(CompositeFutureImpl.java:109) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl$3.onSuccess(FutureImpl.java:124) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:62) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:179) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) [kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472) [kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500) [kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989) [kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [kafka-admin-0.0.8-SNAPSHOT-fat.jar:0.0.8-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```