### PR TITLE
Add release actions

### DIFF
--- a/.github/project-prototype.yml
+++ b/.github/project-prototype.yml
@@ -1,0 +1,4 @@
+name: Kafka Admin Server
+release:
+  current-version: 0.0.7
+  next-version: 0.0.8-SNAPSHOT

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
     types: [ opened, reopened, synchronize ]
 
 jobs:
@@ -11,12 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: '11'
+          distribution: 'adopt'
 
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@v1

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,28 @@
+name: Pre-Release
+
+on:
+  pull_request:
+    paths:
+      - '.github/project.yml'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: pre release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Retrieve Project Metadata
+        uses: radcortez/project-metadata-action@243817f1e0f2b4df4e012fc17efc45cff166425d
+        id: metadata
+        with:
+          metadata-file-path: '.github/project.yml'
+          local-file: true
+
+      - name: Review Milestone
+        uses: radcortez/milestone-review-action@d75da69716e15f9ea52c5b77eb8bf3cfdd8299ad
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          milestone-title: ${{steps.metadata.outputs.current-version}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - '.github/project.yml'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: release
+    if: ${{github.event.pull_request.merged == true}}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Retrieve Project Metadata
+        uses: radcortez/project-metadata-action@243817f1e0f2b4df4e012fc17efc45cff166425d
+        id: metadata
+        with:
+          metadata-file-path: '.github/project.yml'
+          local-file: true
+
+      - name: Setup JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Perform Maven Release
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b release
+          mvn -B release:prepare -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}
+          git checkout ${{github.base_ref}}
+          git rebase release
+          mvn -B release:perform
+
+      - name: Setup Docker
+        uses: docker-practice/actions-setup-docker@v1
+
+      - name: Build and Push Image
+        run: |
+          # Use `target/checkout` as the Docker build PATH, Maven release:perform has generated the release artifacts in that location
+          docker build -t ${{secrets.IMAGE_REPO_HOSTNAME}}/${{secrets.IMAGE_REPO_NAMESPACE}}/kafka-admin-api:${{steps.metadata.outputs.current-version}} --build-arg kafka_admin_api_version=${{steps.metadata.outputs.current-version}} target/checkout
+          docker login -u="${{secrets.IMAGE_REPO_USERNAME}}" -p="${{secrets.IMAGE_REPO_PASSWORD}}" ${{secrets.IMAGE_REPO_HOSTNAME}}
+          docker push ${{secrets.IMAGE_REPO_HOSTNAME}}/${{secrets.IMAGE_REPO_NAMESPACE}}/kafka-admin-api:${{steps.metadata.outputs.current-version}}
+
+      - name: Push Release Tag
+        run: |
+          git push
+          git push --tags
+
+      - name: Create GitHub Release
+        uses: radcortez/milestone-release-action@98bd3321583e9bdbbe15c08fa4b2249371efaeaa
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          milestone-title: ${{steps.metadata.outputs.current-version}}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,22 @@ Once all steps above have been completed, you can run the Kafka Admin API. The s
 
 ## Releasing
 
-Interim release steps
+### Milestones
+Each release requires an open milestone that includes the issues/pull requests that are part of the release. All issues in the release milestone must be closed. The name of the milestone must match the version number to be released.
+
+### Configuration
+The release action flow requires that the following secrets are configured in the repository:
+* `IMAGE_REPO_HOSTNAME` - the host (optionally including a port number) of the image repository where images will be pushed
+* `IMAGE_REPO_NAMESPACE` - namespace/library/user where the image will be pushed
+* `IMAGE_REPO_USERNAME` - user name for authentication to server `IMAGE_REPO_HOSTNAME`
+* `IMAGE_REPO_PASSWORD` - password for authentication to server `IMAGE_REPO_HOSTNAME`
+These credentials will be used to push the release image to the repository configured in the `.github/workflows/release.yml` workflow.
+
+### Performing the Release
+Releases are performed by modifying the `.github/project.yml` file, setting `current-version` to the release version and `next-version` to the next SNAPSHOT. Open a pull request with the changed `project.yml` to initiate the pre-release workflows. At this phase, the project milestone will be checked and it will be verified that no issues for the release milestone are still open. Additionally, the project's integration test will be run.
+Once approved and the pull request is merged, the release action will execute. This action will execute the Maven release plugin to tag the release commit, build the application artifacts, create the build image, and push the image to (currently) quay.io. If successful, the action will push the new tag to the Github repository and generate release notes listing all of the closed issues included in the milestone. Finally, the milestone will be closed.
+
+## Interim release steps (DEPRECATED)
 
 ```
 DOCKER_REPO=quay.io/k_wall

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,12 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 
+    <scm>
+        <connection>scm:git:git://github.com/bf2fc6cc711aee1a0c2a/kafka-admin-api.git</connection>
+        <developerConnection>scm:git:git@github.com:bf2fc6cc711aee1a0c2a/kafka-admin-api.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -298,6 +304,21 @@
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>
                     </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                    <preparationGoals>verify</preparationGoals>
+                    <pushChanges>false</pushChanges>
+                    <localCheckout>true</localCheckout>
+                    <remoteTagging>false</remoteTagging>
+                    <arguments>-DskipTests -DskipITs -Dmaven.deploy.skip=true ${release.arguments}</arguments>
+                    <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
For discussion... these new actions will allow for releases to done by modifying the `release.yml` file (here named `release-prototype.yml` to avoid an unintended release on the initial PR merge). The actions still need to be updated to use the correct quay.io repository (it's currently pushing to my personal namespace) and I have a PR open to Roberto Cortez to add support for private repos to his milestone action. I won't restate it here, but there is documentation added to the README about how this work. 

I'm interested in hearing the team's feedback on this approach, which I think we can also use for fleetshard.

CC: @shawkins, @ppatierno, @k-wall 