### PR TITLE
Fix test flake and re-enable

### DIFF
--- a/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/oauth/ConsumerGroupsOAuthTestIT.java
+++ b/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/oauth/ConsumerGroupsOAuthTestIT.java
@@ -59,7 +59,7 @@ public class ConsumerGroupsOAuthTestIT extends OauthTestBase {
     }
 
     @Test
-    public void testListWithInvalidToken(Vertx vertx, VertxTestContext testContext) throws Exception {
+    public void testConsumerGroupsListWithInvalidToken(Vertx vertx, VertxTestContext testContext) throws Exception {
         List<String> groupIDS = SyncMessaging.createConsumerGroups(vertx, kafkaClient, 1, "localhost:9092", testContext, token);
         kafkaClient.close();
         String invalidToken = new Random().ints(97, 98)

--- a/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/oauth/RestOAuthTestIT.java
+++ b/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/oauth/RestOAuthTestIT.java
@@ -13,7 +13,6 @@ import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.config.ConfigResource;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -84,9 +83,8 @@ public class RestOAuthTestIT extends OauthTestBase {
 
     }
 
-    @Disabled
     @Test
-    public void testListWithInvalidToken(Vertx vertx, VertxTestContext testContext) throws Exception {
+    public void testTopicsListWithInvalidToken(Vertx vertx, VertxTestContext testContext) throws Exception {
         List<String> topicNames = new ArrayList<>();
         topicNames.add(UUID.randomUUID().toString());
         topicNames.add(UUID.randomUUID().toString());


### PR DESCRIPTION
The `RestOAuthTestIT#testListWithInvalidToken` test worked in isolation, but would consistently fail when run as part of the entire suite.

The reason it was failing in that scenario is because there's a static global map in the AdminDeploymentManager to keep track of all of the ports for admin server instances for tests, with the map keys being the test method names. The problem in this case is that there were two tests with the same name in two different classes, and the other one would be run first. When it came time to run this test, there would already be a port registered for the test method name from the other test, and `ADMIN_PORTS.putIfAbsent` wouldn't "put" because "not absent". This test would then have the wrong port registered, and the call to list topics would time out (never reach the server because it was trying on the wrong port).