### PR TITLE
Bump ubi8/openjdk-11 to 1.3-15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.3-11
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.3-15
 
 ENV KAFKA_ADMIN_API_HOME=/opt/kafka-admin-api
 WORKDIR ${KAFKA_ADMIN_API_HOME}


### PR DESCRIPTION
To avoid releasing 0.0.8 with known upstream vulnerabilities. 