### PR TITLE
ci: notify SDK when the OpenAPI spec has changed

### DIFF
--- a/.github/workflows/openapi_update.yaml
+++ b/.github/workflows/openapi_update.yaml
@@ -1,0 +1,27 @@
+name: Dispatch OpenAPI File Change event
+on:
+  push:
+    branches: 
+      - main
+    paths:
+      - "./kafka-admin/src/main/resources/openapi-specs/rest.yaml"
+
+jobs:
+  dispatch:
+    env:
+      APP_SERVICES_CI_TOKEN: "{{ secrets.APP_SERVICES_CI_TOKEN }}"
+    strategy:
+      matrix:
+        repo: ["redhat-developer/app-services-sdk-go", "redhat-developer/app-services-sdk-js"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: "${{ env.APP_SERVICES_CI_TOKEN }}"
+          repository: ${{ matrix.repo }}
+          event-type: openapi-spec-change
+          client-payload: '{
+            "id": "kafka-admin/v1",
+            "openapi": "./kafka-admin/src/main/resources/openapi-specs/rest.yaml"
+          }'


### PR DESCRIPTION
This is an action which copies https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/.github/workflows/openapi_update.yaml to notify the SDKs when a change to the OAS has occurred. This enables generation of a new API client.