### PR TITLE
fix: make openapi update job aligned with config

### DIFF
--- a/.github/workflows/openapi_update.yaml
+++ b/.github/workflows/openapi_update.yaml
@@ -4,7 +4,7 @@ on:
     branches: 
       - main
     paths:
-      - "./kafka-admin/src/main/resources/openapi-specs/rest.yaml"
+      - "kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml"
 
 jobs:
   dispatch:
@@ -21,7 +21,4 @@ jobs:
           token: "${{ env.APP_SERVICES_CI_TOKEN }}"
           repository: ${{ matrix.repo }}
           event-type: openapi-spec-change
-          client-payload: '{
-            "id": "kafka-admin/v1",
-            "openapi": "./kafka-admin/src/main/resources/openapi-specs/rest.yaml"
-          }'
+          client-payload: '{ "id": "kafka-admin/v1", "download_url": "https://raw.githubusercontent.com/bf2fc6cc711aee1a0c2a/kafka-admin-api/main/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml"}'

--- a/kafka-admin/src/main/java/org/bf2/admin/http/server/AdminServer.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/http/server/AdminServer.java
@@ -99,7 +99,7 @@ public class AdminServer extends AbstractVerticle {
         // OpenAPI contract document served at `/rest/openapi`
         options.setContractEndpoint(RouterBuilderOptions.STANDARD_CONTRACT_ENDPOINT);
 
-        return RouterBuilder.create(vertx, "openapi-specs/rest.yaml")
+        return RouterBuilder.create(vertx, "openapi-specs/kafka-admin-rest.yaml")
             .onSuccess(builder -> {
                 builder.setOptions(options);
                 assignRoutes(builder, vertx);

--- a/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml
+++ b/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Kafka Admin REST API
-  version: 0.1.0
+  version: 0.2.0
   description: An API to provide REST endpoints for query Kafka for admin operations
   license:
     name: Apache 2.0


### PR DESCRIPTION
This PR fixes generic name for the kafka openapi file and also making small changes in the actual job that pushes updates.

Review:
 @craicoverflow @sknot-rh @MikeEdgar @grdryn 