### PR TITLE
ci: fix bad expression assignment

### DIFF
--- a/.github/workflows/openapi_update.yaml
+++ b/.github/workflows/openapi_update.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   dispatch:
     env:
-      APP_SERVICES_CI_TOKEN: "{{ secrets.APP_SERVICES_CI_TOKEN }}"
+      APP_SERVICES_CI_TOKEN: "${{ secrets.APP_SERVICES_CI_TOKEN }}"
     strategy:
       matrix:
         repo: ["redhat-developer/app-services-sdk-go", "redhat-developer/app-services-sdk-js"]


### PR DESCRIPTION
The `APP_SERVICES_CI_TOKEN` env was not being assigned to the secret value as it was missing the `$` needed to call the expression.

cc @sknot-rh @wtrocki 