### PR TITLE
Bump ubi8/openjdk-11 to 1.3-15.1622643823

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.3-15
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.3-15.1622643823
 
 ENV KAFKA_ADMIN_API_HOME=/opt/kafka-admin-api
 WORKDIR ${KAFKA_ADMIN_API_HOME}


### PR DESCRIPTION
Resolves security issues from 1.3-15

https://catalog.redhat.com/software/containers/ubi8/openjdk-11/5dd6a4b45a13461646f677f4
