### PR TITLE
Add support for a trusted certificate for the OAuth JWKS endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Once all steps above have been completed, you can run the Kafka Admin API. The s
 | CORS_ALLOW_LIST_REGEX | Regular expression to match origins for CORS. An origin follows rfc6454#section-7 and is expected to have the format: `<scheme> "://" <hostname> [ ":" <port> ]` |
 | KAFKA_ADMIN_BOOTSTRAP_SERVERS | A comma-separated list of host and port pairs that are the addresses of the Kafka brokers in a "bootstrap" Kafka cluster.   |
 | KAFKA_ADMIN_OAUTH_ENABLED | Enables a third party application to obtain limited access to the Admin API. |
+| KAFKA_ADMIN_OAUTH_TRUSTED_CERT | Certificate in PEM format used by the JWKS and token endpoints. Optional when the endpoints use self-signed or otherwise untrusted certificates. Only valid if OAuth and JWKS endpoint are enabled. |
 | KAFKA_ADMIN_OAUTH_JWKS_ENDPOINT_URI | Endpoint serving JWKS to be use to verify JWT access tokens. *required when `KAFKA_ADMIN_OAUTH_ENABLED` is used* |
 | KAFKA_ADMIN_OAUTH_VALID_ISSUER_URI | Optional issuer that, when provided, must match the issuer (`iss` claim) present in JWTs. Only valid if OAuth and JWKS endpoint are enabled. |
 | KAFKA_ADMIN_OAUTH_TOKEN_ENDPOINT_URI | Optional token endpoint that will be published in the OpenAPI document describing the REST service. Only valid if OAuth and JWKS endpoint are enabled. |

--- a/kafka-admin/src/main/java/org/bf2/admin/http/server/AdminServer.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/http/server/AdminServer.java
@@ -7,10 +7,12 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.OAuth2FlowType;
@@ -169,6 +171,14 @@ public class AdminServer extends AbstractVerticle {
         oauthOptions.setFlow(OAuth2FlowType.CLIENT);
         oauthOptions.setJwkPath(config.getOauthJwksEndpointUri());
         oauthOptions.setValidateIssuer(true);
+
+        String oauthTrustedCertificate = config.getOauthTrustedCertificate();
+
+        if (oauthTrustedCertificate != null) {
+            PemTrustOptions trustOptions = new PemTrustOptions();
+            setCertConfig(oauthTrustedCertificate, trustOptions::addCertPath, trustOptions::addCertValue);
+            oauthOptions.setHttpClientOptions(new HttpClientOptions().setPemTrustOptions(trustOptions));
+        }
 
         if (config.getOauthValidIssuerUri() != null) {
             LOGGER.info("JWT issuer (iss) claim valid value: {}", config.getOauthValidIssuerUri());

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/KafkaAdminConfigRetriever.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/KafkaAdminConfigRetriever.java
@@ -25,6 +25,7 @@ public class KafkaAdminConfigRetriever {
 
     public static final String BOOTSTRAP_SERVERS = PREFIX + "BOOTSTRAP_SERVERS";
     public static final String OAUTH_ENABLED = PREFIX + "OAUTH_ENABLED";
+    public static final String OAUTH_TRUSTED_CERT = PREFIX + "OAUTH_TRUSTED_CERT";
     public static final String OAUTH_JWKS_ENDPOINT_URI = PREFIX + "OAUTH_JWKS_ENDPOINT_URI";
     public static final String OAUTH_VALID_ISSUER_URI = PREFIX + "OAUTH_VALID_ISSUER_URI";
     public static final String OAUTH_TOKEN_ENDPOINT_URI = PREFIX + "OAUTH_TOKEN_ENDPOINT_URI";
@@ -82,6 +83,10 @@ public class KafkaAdminConfigRetriever {
 
     public Map<String, Object> getAcConfig() {
         return new HashMap<>(acConfig);
+    }
+
+    public String getOauthTrustedCertificate() {
+        return System.getenv(OAUTH_TRUSTED_CERT);
     }
 
     public String getOauthJwksEndpointUri() {


### PR DESCRIPTION
I overlooked the need for this until integrating with Fleetshard and using a self-signed certificate with Keycloak in the system tests.

Signed-off-by: Michael Edgar <medgar@redhat.com>