### PR TITLE
Fix the validation of CG offset reset parameters

### DIFF
--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/ConsumerGroupOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/ConsumerGroupOperations.java
@@ -146,10 +146,14 @@ public class ConsumerGroupOperations {
         });
     }
 
-    @SuppressWarnings({"checkstyle:JavaNCSS"})
+    @SuppressWarnings({"checkstyle:JavaNCSS", "checkstyle:MethodLength"})
     public static void resetGroupOffset(KafkaAdminClient ac, Types.ConsumerGroupOffsetResetParameters parameters, Promise prom) {
         Set<TopicPartition> topicPartitionsToReset = new HashSet<>();
         List<Future> promises = new ArrayList<>();
+        if (!"latest".equals(parameters.getOffset()) && !"earliest".equals(parameters.getOffset()) && parameters.getValue() == null) {
+            throw new InvalidRequestException("Value has to be set when " + parameters.getOffset() + " offset is used.");
+        }
+
         if (parameters.getTopics() == null || parameters.getTopics().isEmpty()) {
             // reset everything
             Promise promise = Promise.promise();

--- a/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml
+++ b/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml
@@ -885,7 +885,6 @@ components:
       description: ''
       required:
         - offset
-        - value
       type: object
       properties:
         value:


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Fixes https://github.com/bf2fc6cc711aee1a0c2a/kafka-admin-api/issues/89
The `value` property cannot be required as `latest` and `earliest` do not need it. However, for `timestamp` and `absolute` it is required. So we need to check whether it is provided in the later cases.