### PR TITLE
fix(openapi): rename partitions key for UpdateTopicInput

### DIFF
--- a/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml
+++ b/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml
@@ -873,7 +873,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ConfigEntry'
-        partitions:
+        numPartitions:
           description: Number of partitions (only increasing supported)
           type: integer
       example:


### PR DESCRIPTION
`partitions` key for `UpdateTopicInput` has been renamed to `numPartitions`.

fixes: #96 

Cc: @MikeEdgar 