### PR TITLE
Assign all error responses to Error schema

### DIFF
--- a/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml
+++ b/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml
@@ -1398,7 +1398,7 @@ components:
            schema:
              $ref: '#/components/schemas/Error'
     Conflict:
-      # Status 403
+      # Status 409
       description: The resource already exists.
       content:
          application/json:

--- a/openapitools.json
+++ b/openapitools.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "5.2.0"
+  }
+}


### PR DESCRIPTION
This PR provides every error response with an Error schema. This will allow the SDKs to associate types with errors and gives the consumers access to the properties of the Error object.