### PR TITLE
fix(openapi): change consumergroup reset offset result to object type

### DIFF
--- a/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml
+++ b/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml
@@ -1262,15 +1262,17 @@ components:
         offset: 4
     ResultListPage:
       type: object
+      required:
+        - total
       properties:
         total:
           description: Total number of entries in the full result set
           type: number
         page:
-          description: Current page number
+          description: Current page number (returned for fetch requests)
           type: integer
         size:
-          description: Number of entries per page
+          description: Number of entries per page (returned for fetch requests)
           type: number
     Error:
       description: General error response


### PR DESCRIPTION
### Description

Changed type of `ConsumerGroupResetOffsetResult` from array to object with pagination attributes.

Current type generated from Go sdk:

```
type ConsumerGroupResetOffsetResult struct {

	Items *[]ConsumerGroupResetOffsetResultItem `json:"items,omitempty"`

	// Total number of entries in the full result set
	Total *float32 `json:"total,omitempty"`

	// Current page number
	Page *int32 `json:"page,omitempty"`

	// Number of entries per page
	Size *float32 `json:"size,omitempty"`

}
``` 

addresses #113


### Todo

* Changes in admin api source code.