### PR TITLE
Use runtime openjdk image with custom LEGACY crypto policy

### DIFF
--- a/kafka-admin/src/main/docker/Dockerfile
+++ b/kafka-admin/src/main/docker/Dockerfile
@@ -1,4 +1,10 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.3-18
+FROM registry.access.redhat.com/ubi8/openjdk-11-runtime:1.10-1
+
+USER root
+# Switch to legacy crypto policy and disable the TLS 3DES cipher suites
+RUN update-crypto-policies --set LEGACY && \
+    sed -i 's/jdk.tls.disabledAlgorithms=/jdk.tls.disabledAlgorithms=3DES_EDE_CBC, /' /usr/share/crypto-policies/LEGACY/java.txt
+USER 185
 
 ENV KAFKA_ADMIN_API_HOME=/opt/kafka-admin-api
 WORKDIR ${KAFKA_ADMIN_API_HOME}


### PR DESCRIPTION
- Support additional TLS ciphers
- Disable 3DES_EDE_CBC in crypto policy
- Use runtime openjdk image instead of build/S2I image