### PR TITLE
Poll longer to make tests more stable

### DIFF
--- a/systemtests/src/main/java/org/bf2/admin/kafka/systemtest/utils/SyncMessaging.java
+++ b/systemtests/src/main/java/org/bf2/admin/kafka/systemtest/utils/SyncMessaging.java
@@ -55,7 +55,7 @@ public class SyncMessaging {
 
                             try (var consumer = new KafkaConsumer<>(props)) {
                                 consumer.subscribe(List.of(topic.name()));
-                                consumer.poll(Duration.ofSeconds(1));
+                                consumer.poll(Duration.ofSeconds(4));
                             }
 
                             LOGGER.info("Created group {} on topic {}", groupName, topic.name());


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Kafka seems to be quite clumsy right after the start, so it may happen some requests are not processed properly. In this case, the topic was created but because the poll timeouted the consumer group was not created. Increasing the timeout fixed the issue locally. Let's see, what about actions.