### PR TITLE
Revert "feat(acl): return resource operations mapped to their enum values"

### DIFF
--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/AccessControlOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/AccessControlOperations.java
@@ -76,10 +76,6 @@ public class AccessControlOperations {
         }
     }
 
-    public Map<String, List<String>> getResourceOperations() {
-        return this.resourceOperations;
-    }
-
     public void createAcl(Admin client, Promise<Void> promise, Types.AclBinding binding) {
         if (!validAclBinding(binding)) {
             promise.fail(new IllegalArgumentException(INVALID_ACL_RESOURCE_OPERATION));

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/KafkaAdminConfigRetriever.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/KafkaAdminConfigRetriever.java
@@ -192,7 +192,6 @@ public class KafkaAdminConfigRetriever {
 
     public String getAclResourceOperations() {
         String value = System.getenv(ACL_RESOURCE_OPERATIONS);
-
         return value != null ? value : "{}";
     }
 }

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RestOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RestOperations.java
@@ -1,6 +1,5 @@
 package org.bf2.admin.kafka.admin.handlers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.Timer;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -23,12 +22,9 @@ import org.bf2.admin.kafka.admin.model.Types.PagedResponse;
 import org.bf2.admin.kafka.admin.model.Types.TopicPartitionResetResult;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.TreeMap;
-import java.util.Locale;
-import java.util.Map;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 public class RestOperations extends CommonHandler implements OperationsHandler {
@@ -381,27 +377,8 @@ public class RestOperations extends CommonHandler implements OperationsHandler {
         Timer timer = httpMetrics.getGetAclResourceOperationsRequestTimer();
         Timer.Sample requestTimerSample = Timer.start(httpMetrics.getRegistry());
         Promise<String> promise = Promise.promise();
-
-        // convert the internal resource names and operations and output
-        // the values as they are represented by the ACL resource and operation enum value
-        TreeMap<String, List<String>> mappedResourceOperations = new TreeMap<>();
-        var entries = this.aclOperations.getResourceOperations().entrySet();
-        for (Map.Entry<String, List<String>> mapEntry : entries) {
-            var operations = mapEntry.getValue();
-            var mappedOperations = new ArrayList<String>();
-            for (String operation : operations) {
-                mappedOperations.add(operation.toUpperCase(Locale.ROOT));
-            }
-            mappedResourceOperations.put(mapEntry.getKey().toUpperCase(Locale.ROOT), mappedOperations);
-        }
-
-        try {
-            var resourceOperations = new ObjectMapper().writeValueAsString(mappedResourceOperations);
-            promise.complete(resourceOperations);
-            processResponse(promise, routingContext, HttpResponseStatus.OK, httpMetrics, timer, requestTimerSample);
-        } catch (JsonProcessingException e) {
-            promise.fail(e);
-        }
+        promise.complete(this.kaConfig.getAclResourceOperations());
+        processResponse(promise, routingContext, HttpResponseStatus.OK, httpMetrics, timer, requestTimerSample);
     }
 
     @Override


### PR DESCRIPTION
We need to revert that change as it introduced backwards incompatibile changes. 

 