### PR TITLE
fix: remove deprecated fields that are no longer returned by backend

### DIFF
--- a/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml
+++ b/kafka-admin/src/main/resources/openapi-specs/kafka-admin-rest.yaml
@@ -1159,18 +1159,6 @@ components:
         page:
           description: The page
           type: integer
-        offset:
-          description: Offset of the topic list
-          deprecated: true
-          type: integer
-        limit:
-          description: Maximum of returned topics
-          deprecated: true
-          type: integer
-        count:
-          description: The total number of consumer groups.
-          deprecated: true
-          type: number
       example:
         count: 1
         limit: 10


### PR DESCRIPTION
> NOTE: This change is low priority and doesn't require to be merged till next year

SDK that we currently using are used at compilation time to check compatibility. 
We were based on some deprecated fields. Those fields were still kept but actual responses from backend were changed to remove them. This caused 2 UI components to silently fail as they were still compiling with our SDK (with deprecated fields) but did not get them from running system.


Both QA and Production returning now only:
```
{
  "items" : [ ],
  "size" : 10,
  "page" : 1,
  "total" : 0
}
```

OpenAPI should be updated so we can update our SDKs

