### PR TITLE
Map PolicyViolationException to HTTP status 400

### DIFF
--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/CommonHandler.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/CommonHandler.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.errors.InvalidPartitionsException;
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
+import org.apache.kafka.common.errors.PolicyViolationException;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.errors.SslAuthenticationException;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -203,6 +204,7 @@ public class CommonHandler {
                     && failureCause.getCause().getMessage().contains("Authentication failed due to an invalid token"))) {
             status = HttpResponseStatus.UNAUTHORIZED;
         } else if (failureCause instanceof org.apache.kafka.common.errors.InvalidTopicException
+                || failureCause instanceof PolicyViolationException
                 || failureCause instanceof InvalidReplicationFactorException
                 || failureCause instanceof BadRequestException) {
             status = HttpResponseStatus.BAD_REQUEST;
@@ -211,8 +213,6 @@ public class CommonHandler {
         } else if (failureCause instanceof InvalidRequestException
                 || failureCause instanceof InvalidConfigurationException
                 || failureCause instanceof IllegalArgumentException
-                || failureCause instanceof InvalidReplicationFactorException
-                || failureCause instanceof org.apache.kafka.common.errors.InvalidTopicException
                 || failureCause instanceof InvalidPartitionsException) {
             status = HttpResponseStatus.BAD_REQUEST;
         } else if (failureCause instanceof IllegalStateException) {

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -40,6 +40,11 @@
                         <configuration>
                             <executable>docker</executable>
                             <commandlineArgs>image rm -f kafka-admin</commandlineArgs>
+                            <successCodes>
+                                <successCode>0</successCode>
+                                <!-- Allow error when image does not exist -->
+                                <successCode>1</successCode>
+                            </successCodes>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION

Also
- Remove duplicate exception mappings for `InvalidReplicationFactorException` and `InvalidTopicException`
- Allow rc=1 for test image removal (e.g. when image does not exist)

Signed-off-by: Michael Edgar <medgar@redhat.com>