### PR TITLE
Replace `/rest` paths with `/api/v1` to align with conventions

### DIFF
--- a/kafka-admin/.openapi/kafka-admin-rest.yaml
+++ b/kafka-admin/.openapi/kafka-admin-rest.yaml
@@ -6,7 +6,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
-  version: 0.7.1-SNAPSHOT
+  version: 0.8.1-SNAPSHOT
 servers:
 - url: /
   description: Kafka Admin REST API
@@ -22,7 +22,7 @@ tags:
 - name: records
   description: Send and receive records interactively
 paths:
-  /rest/topics:
+  /api/v1/topics:
     get:
       tags:
       - topics
@@ -132,7 +132,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Topic'
-  /rest/topics/{topicName}:
+  /api/v1/topics/{topicName}:
     get:
       tags:
       - topics
@@ -227,7 +227,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Topic'
-  /rest/consumer-groups:
+  /api/v1/consumer-groups:
     get:
       tags:
       - groups
@@ -338,7 +338,7 @@ paths:
           $ref: '#/components/responses/ServerError'
         "503":
           $ref: '#/components/responses/ServiceUnavailable'
-  /rest/consumer-groups/{consumerGroupId}:
+  /api/v1/consumer-groups/{consumerGroupId}:
     get:
       tags:
       - groups
@@ -427,7 +427,7 @@ paths:
           $ref: '#/components/responses/ServerError'
         "503":
           $ref: '#/components/responses/ServiceUnavailable'
-  /rest/consumer-groups/{consumerGroupId}/reset-offset:
+  /api/v1/consumer-groups/{consumerGroupId}/reset-offset:
     post:
       tags:
       - groups
@@ -469,7 +469,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConsumerGroupResetOffsetResult'
-  /rest/acls:
+  /api/v1/acls:
     get:
       tags:
       - acls
@@ -756,7 +756,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AclBindingListPage'
-  /rest/acls/resource-operations:
+  /api/v1/acls/resource-operations:
     get:
       tags:
       - acls
@@ -792,7 +792,7 @@ paths:
           $ref: '#/components/responses/NotAuthorized'
         "500":
           $ref: '#/components/responses/ServerError'
-  /rest/topics/{topicName}/records:
+  /api/v1/topics/{topicName}/records:
     get:
       tags:
       - records

--- a/kafka-admin/pom.xml
+++ b/kafka-admin/pom.xml
@@ -46,7 +46,6 @@
                                         <kafka.admin.oauth.token.endpoint.uri>/token</kafka.admin.oauth.token.endpoint.uri>
                                         <kafka.admin.num.partitions.max>100</kafka.admin.num.partitions.max>
                                     </systemPropertyVariables>
-                                    
                                     <schemaFilename>kafka-admin-rest</schemaFilename>
                                     <filter>org.bf2.admin.kafka.admin.handlers.OASModelFilter</filter>
                                     <infoVersion>${project.version}</infoVersion>
@@ -174,12 +173,20 @@
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-web</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.common</groupId>
             <artifactId>smallrye-common-annotation</artifactId>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-kafka-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logmanager</groupId>
@@ -245,6 +252,11 @@
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
             <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/HttpMetrics.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/HttpMetrics.java
@@ -12,6 +12,8 @@ import javax.inject.Inject;
 public class HttpMetrics {
     private static final String FAILED_REQUESTS_COUNTER = "failed_requests";
     private static final String HTTP_STATUS_CODE = "status_code";
+    private static final String DEPRECATED_REQUESTS_COUNTER = "deprecated_requests";
+    private static final String DEPRECATED_REQUESTS_PATH = "path";
 
     @Inject
     PrometheusMeterRegistry meterRegistry;
@@ -23,11 +25,14 @@ public class HttpMetrics {
     public void init(@Observes StartupEvent event) {
         requestsCounter = meterRegistry.counter("requests");
         openApiCounter = meterRegistry.counter("requests_openapi");
+        succeededRequestsCounter = meterRegistry.counter("succeeded_requests");
+
         /*
          * Status code 404 is a placeholder for defining the status_code label.
          */
         meterRegistry.counter(FAILED_REQUESTS_COUNTER, HTTP_STATUS_CODE, "404");
-        succeededRequestsCounter = meterRegistry.counter("succeeded_requests");
+        meterRegistry.counter(DEPRECATED_REQUESTS_COUNTER, DEPRECATED_REQUESTS_PATH, "/rest/openapi");
+
     }
 
     public PrometheusMeterRegistry getRegistry() {
@@ -50,4 +55,7 @@ public class HttpMetrics {
         return succeededRequestsCounter;
     }
 
+    public Counter getDeprecatedRequestCounter(String path) {
+        return getRegistry().counter(DEPRECATED_REQUESTS_COUNTER, DEPRECATED_REQUESTS_PATH, path);
+    }
 }

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RequestRewriter.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RequestRewriter.java
@@ -1,0 +1,38 @@
+package org.bf2.admin.kafka.admin.handlers;
+
+import io.quarkus.vertx.web.RouteFilter;
+import io.vertx.ext.web.RoutingContext;
+import org.bf2.admin.kafka.admin.HttpMetrics;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class RequestRewriter {
+
+    private static final Logger LOG = Logger.getLogger(RequestRewriter.class);
+    private static final String REST = "/rest";
+    private static final String OPENAPI = "/openapi";
+
+    @Inject
+    HttpMetrics httpMetrics;
+
+    @RouteFilter(400)
+    void filterRequest(RoutingContext context) {
+        String requestUri = context.request().uri();
+
+        if (requestUri.startsWith(REST)) {
+            httpMetrics.getDeprecatedRequestCounter(requestUri).increment();
+
+            String remainingPath = requestUri.substring(REST.length());
+            String target = remainingPath.startsWith(OPENAPI) ? remainingPath : "/api/v1" + remainingPath;
+            LOG.infof("Rerouting deprecated request: %s -> %s", requestUri, target);
+
+            context.reroute(target);
+            return;
+        }
+
+        context.next();
+    }
+}

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RestOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RestOperations.java
@@ -32,7 +32,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
-@Path("/rest")
+@Path("/api/v1")
 public class RestOperations implements OperationsHandler {
 
     private static final Logger log = Logger.getLogger(RestOperations.class);

--- a/kafka-admin/src/main/resources/META-INF/openapi.yaml
+++ b/kafka-admin/src/main/resources/META-INF/openapi.yaml
@@ -26,7 +26,7 @@ tags:
   - name: records
     description: Send and receive records interactively
 paths:
-  /rest/topics:
+  /api/v1/topics:
     get:
       # Parameters listed to establish a fixed order (support stability for downstream generated code)
       parameters:
@@ -38,9 +38,9 @@ paths:
         - { in: query, schema: {}, name: order }
         - { in: query, schema: {}, name: orderKey }
 
-  /rest/topics/{topicName}: {}
+  /api/v1/topics/{topicName}: {}
 
-  /rest/consumer-groups:
+  /api/v1/consumer-groups:
     get:
       # Parameters listed to establish a fixed order (support stability for downstream generated code)
       parameters:
@@ -88,7 +88,7 @@ paths:
                             lag: 1
                             logEndOffset: 5
 
-  /rest/consumer-groups/{consumerGroupId}:
+  /api/v1/consumer-groups/{consumerGroupId}:
     get:
       # Parameters listed to establish a fixed order (support stability for downstream generated code)
       parameters:
@@ -98,9 +98,9 @@ paths:
         - { in: query, schema: {}, name: partitionFilter }
         - { in: query, schema: {}, name: topic }
 
-  /rest/consumer-groups/{consumerGroupId}/reset-offset: {}
+  /api/v1/consumer-groups/{consumerGroupId}/reset-offset: {}
 
-  /rest/acls:
+  /api/v1/acls:
     get:
       parameters:
       # Parameters listed to establish a fixed order (support stability for downstream generated code)
@@ -124,7 +124,7 @@ paths:
       - { in: query, schema: {}, name: operation }
       - { in: query, schema: {}, name: permission }
 
-  /rest/acls/resource-operations:
+  /api/v1/acls/resource-operations:
     get:
       responses:
         "200":

--- a/kafka-admin/src/main/resources/application.properties
+++ b/kafka-admin/src/main/resources/application.properties
@@ -33,8 +33,6 @@ mp.jwt.verify.issuer=${kafka.admin.oauth.valid.issuer.uri: }
 
 mp.openapi.scan.disable=false
 mp.openapi.filter=org.bf2.admin.kafka.admin.handlers.OASModelFilter
-# Needed following migration from Vert.x to SmallRye OpenAPI
-quarkus.smallrye-openapi.path=/rest/openapi
 quarkus.smallrye-openapi.info-version=${quarkus.application.version:0.0.1-SNAPSHOT}
 
 quarkus.log.category."org.apache.kafka".level=WARN

--- a/kafka-admin/src/test/java/org/bf2/admin/kafka/admin/handlers/RequestRewriterTest.java
+++ b/kafka-admin/src/test/java/org/bf2/admin/kafka/admin/handlers/RequestRewriterTest.java
@@ -1,0 +1,72 @@
+package org.bf2.admin.kafka.admin.handlers;
+
+import io.micrometer.core.instrument.Counter;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import org.bf2.admin.kafka.admin.HttpMetrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RequestRewriterTest {
+
+    RoutingContext context;
+    HttpServerRequest request;
+    Counter deprecatedCounter;
+    RequestRewriter target;
+
+    @BeforeEach
+    void setup() {
+        context = Mockito.mock(RoutingContext.class);
+        request = Mockito.mock(HttpServerRequest.class);
+        when(context.request()).thenReturn(request);
+
+        HttpMetrics httpMetrics = Mockito.mock(HttpMetrics.class);
+        deprecatedCounter = mock(Counter.class);
+        when(httpMetrics.getDeprecatedRequestCounter(anyString())).thenReturn(deprecatedCounter);
+
+        target = new RequestRewriter();
+        target.httpMetrics = httpMetrics;
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "/rest,                     /api/v1",
+        "/rest/openapi?format=JSON, /openapi?format=JSON",
+        "/rest/topics,              /api/v1/topics",
+    })
+    void testDeprecatedRequestsForwarded(String original, String forwarded) {
+        when(request.uri()).thenReturn(original);
+
+        target.filterRequest(context);
+
+        verify(context, times(1)).reroute(forwarded);
+        verify(context, never()).next();
+        verify(deprecatedCounter, times(1)).increment();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "/api/v1",
+        "/openapi?format=JSON",
+        "/api/v1/topics",
+    })
+    void testCurrentRequestsProcessed(String uri) {
+        when(request.uri()).thenReturn(uri);
+
+        target.filterRequest(context);
+
+        verify(context, times(1)).next();
+        verify(context, never()).reroute(anyString());
+        verify(deprecatedCounter, never()).increment();
+    }
+}

--- a/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/oauth/RestOAuthTestIT.java
+++ b/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/oauth/RestOAuthTestIT.java
@@ -205,7 +205,7 @@ class RestOAuthTestIT {
             .log().ifValidationFails()
             .statusCode(Status.CREATED.getStatusCode())
         .assertThat()
-            .header("Location", equalTo("/rest/topics/" + topicName))
+            .header("Location", equalTo("/api/v1/topics/" + topicName))
             .body("name", equalTo(topicName))
             .body("isInternal", equalTo(false))
             .body("partitions.size()", equalTo(numPartitions))

--- a/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/plain/RecordEndpointTestIT.java
+++ b/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/plain/RecordEndpointTestIT.java
@@ -64,7 +64,7 @@ class RecordEndpointTestIT {
         .then()
             .log().ifValidationFails()
             .statusCode(Status.CREATED.getStatusCode())
-            .header("Location", stringContainsInOrder("/rest/topics/" + topicName + "/records", "partition=" + partition))
+            .header("Location", stringContainsInOrder("/api/v1/topics/" + topicName + "/records", "partition=" + partition))
             .body("partition", equalTo(partition))
             .body("timestamp", equalTo(timestamp.toString()))
             .body("value", equalTo("record value"))

--- a/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/plain/RestEndpointTestIT.java
+++ b/systemtests/src/test/java/org/bf2/admin/kafka/systemtest/plain/RestEndpointTestIT.java
@@ -390,7 +390,7 @@ class RestEndpointTestIT {
             .log().ifValidationFails()
             .statusCode(Status.CREATED.getStatusCode())
         .assertThat()
-            .header("Location", equalTo("/rest/topics/" + topicName))
+            .header("Location", equalTo("/api/v1/topics/" + topicName))
             .body("name", equalTo(topicName))
             .body("isInternal", equalTo(false))
             .body("partitions.size()", equalTo(numPartitions))


### PR DESCRIPTION
`RequestRewriter` provides backward compatibility for existing clients using previous `/rest` paths.

MGDSTRM-7823