### PR TITLE
[MGDSTRM-7892] Add `max.block.ms` to producer client configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_JMX_PORT: 9101
       KAFKA_JMX_HOSTNAME: localhost
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/AdminClientFactory.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/AdminClientFactory.java
@@ -160,6 +160,7 @@ public class AdminClientFactory {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
         props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 5000);
 
         return new KafkaProducer<>(props);
     }

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -10,10 +10,10 @@
 
     <properties>
         <hamcrest.version>2.1</hamcrest.version>
-        <strimzi-test-container.version>0.25.0</strimzi-test-container.version>
+        <strimzi-test-container.version>0.101.0</strimzi-test-container.version>
         <!-- System test image dependencies -->
         <keycloak.image>quay.io/keycloak/keycloak:14.0.0</keycloak.image>
-        <strimzi-kafka.tag>0.26.0-kafka-2.8.1</strimzi-kafka.tag>
+        <strimzi-kafka.tag>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</strimzi-kafka.tag>
     </properties>
 
     <build>

--- a/systemtests/src/main/java/org/bf2/admin/kafka/systemtest/deployment/DeploymentManager.java
+++ b/systemtests/src/main/java/org/bf2/admin/kafka/systemtest/deployment/DeploymentManager.java
@@ -1,6 +1,6 @@
 package org.bf2.admin.kafka.systemtest.deployment;
 
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 import org.bf2.admin.kafka.admin.KafkaAdminConfigRetriever;
 import org.bf2.admin.kafka.systemtest.Environment;
 import org.jboss.logging.Logger;
@@ -331,6 +331,7 @@ public class DeploymentManager {
                 .withLabels(Collections.singletonMap("test-ident", Environment.TEST_CONTAINER_LABEL))
                 .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("systemtests.plain-kafka"), true))
                 .withCreateContainerCmdModifier(cmd -> cmd.withName(name("plain-kafka")))
+                .withKafkaConfigurationMap(Map.of("auto.create.topics.enable", "false"))
                 .withNetwork(testNetwork);
 
         container.start();

--- a/systemtests/src/main/java/org/bf2/admin/kafka/systemtest/deployment/KeycloakSecuredKafkaContainer.java
+++ b/systemtests/src/main/java/org/bf2/admin/kafka/systemtest/deployment/KeycloakSecuredKafkaContainer.java
@@ -20,8 +20,8 @@ class KeycloakSecuredKafkaContainer extends GenericContainer<KeycloakSecuredKafk
     private int kafkaExposedPort;
     private StringBuilder advertisedListeners;
 
-    KeycloakSecuredKafkaContainer(String version) {
-        super(version);
+    KeycloakSecuredKafkaContainer(String imageName) {
+        super(imageName);
         withExposedPorts(KAFKA_PORT);
     }
 

--- a/systemtests/src/main/java/org/bf2/admin/kafka/systemtest/deployment/KeycloakSecuredKafkaContainer.java
+++ b/systemtests/src/main/java/org/bf2/admin/kafka/systemtest/deployment/KeycloakSecuredKafkaContainer.java
@@ -21,7 +21,7 @@ class KeycloakSecuredKafkaContainer extends GenericContainer<KeycloakSecuredKafk
     private StringBuilder advertisedListeners;
 
     KeycloakSecuredKafkaContainer(String version) {
-        super("quay.io/strimzi/kafka:" + version);
+        super(version);
         withExposedPorts(KAFKA_PORT);
     }
 


### PR DESCRIPTION
- Disable `auto.create.topics.enable` for tests/docker-compose setup
- Bump strimzi-test-container verison to support easier configuration of
`auto.create.topics.enable`

Diff is simpler with [whitespace changes hidden](https://github.com/bf2fc6cc711aee1a0c2a/kafka-admin-api/pull/186/files?w=1).