### PR TITLE
[MGDSTRM-7897] Corrected property for CORS origin pattern

### DIFF
--- a/kafka-admin/src/main/resources/application.properties
+++ b/kafka-admin/src/main/resources/application.properties
@@ -6,7 +6,7 @@ quarkus.http.access-log.exclude-pattern=(?:/health(/live|/ready|/started)?|/metr
 quarkus.http.non-application-root-path=${quarkus.http.root-path}
 
 quarkus.http.cors=true
-quarkus.http.cors.origins=${CORS_ALLOW_LIST_REGEX:}
+quarkus.http.cors.origins=/${CORS_ALLOW_LIST_REGEX:.*}/
 quarkus.http.cors.methods=GET,POST,PATCH,DELETE,OPTIONS
 quarkus.http.cors.headers=Access-Control-Request-Method,Access-Control-Allow-Credentials,Access-Control-Allow-Origin,Access-Control-Allow-Headers,Authorization,Content-Type
 quarkus.http.cors.access-control-max-age=PT2H


### PR DESCRIPTION
Quarkus requires entries in `quarkus.http.cors.origins` to be surrounded by forward-slash characters to treat it as a regular expression.