### PR TITLE
Release 0.9.0 (retry)

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,3 +2,4 @@ name: Kafka Admin Server
 release:
   current-version: 0.9.0
   next-version: 0.9.1-SNAPSHOT
+


### PR DESCRIPTION
Reattempt release. GH actions do not seem to be triggering properly.