### PR TITLE
[MGDSTRM-8289] Message consumer enhancements

### DIFF
--- a/kafka-admin/.openapi/kafka-admin-rest.yaml
+++ b/kafka-admin/.openapi/kafka-admin-rest.yaml
@@ -824,6 +824,16 @@ paths:
           default: "20"
           minimum: 1
           type: integer
+      - name: maxValueLength
+        in: query
+        description: "Maximum length of string values returned in the response. Values\
+          \ with a length that exceeds this parameter will be truncated. When this\
+          \ parameter is not included in the request, the full string values will\
+          \ be returned."
+        schema:
+          format: int32
+          minimum: 1
+          type: integer
       - name: offset
         in: query
         description: "Retrieve messages with an offset equal to or greater than this\

--- a/kafka-admin/.openapi/kafka-admin-rest.yaml
+++ b/kafka-admin/.openapi/kafka-admin-rest.yaml
@@ -6,7 +6,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
-  version: 0.8.1-SNAPSHOT
+  version: 0.10.0
 servers:
 - url: /
   description: Kafka Admin REST API
@@ -822,6 +822,7 @@ paths:
         schema:
           format: int32
           default: "20"
+          minimum: 1
           type: integer
       - name: offset
         in: query
@@ -830,6 +831,7 @@ paths:
           \ given preference."
         schema:
           format: int32
+          minimum: 0
           type: integer
       - name: partition
         in: query

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/RecordOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/RecordOperations.java
@@ -79,10 +79,16 @@ public class RecordOperations {
                             consumer.seekToEnd(List.of(p));
                         }
                     });
-            } else if (offset != null) {
+            } else {
                 Map<TopicPartition, Long> endOffsets = consumer.endOffsets(assignments);
+
                 assignments.forEach(p -> {
-                    if (offset <= endOffsets.get(p)) {
+                    long partitionEnd = endOffsets.get(p);
+
+                    if (offset == null) {
+                        // Fetch the latest records
+                        consumer.seek(p, Math.max(partitionEnd - limit, 0));
+                    } else if (offset <= partitionEnd) {
                         consumer.seek(p, offset);
                     } else {
                         /*

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/AdminClientFactory.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/AdminClientFactory.java
@@ -9,7 +9,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.bf2.admin.kafka.admin.KafkaAdminConfigRetriever;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jboss.logging.Logger;
@@ -103,7 +103,7 @@ public class AdminClientFactory {
                 .map(credentials -> String.format(SASL_PLAIN_CONFIG_TEMPLATE, credentials[0], credentials[1]));
     }
 
-    public Consumer<String, String> createConsumer(Integer limit) {
+    public Consumer<byte[], byte[]> createConsumer(Integer limit) {
         Map<String, Object> props = config.getConsumerConfig();
 
         if (config.isOauthEnabled()) {
@@ -125,8 +125,8 @@ public class AdminClientFactory {
 
         //props.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
         props.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false");
-        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 50_000);
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RestOperations.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/RestOperations.java
@@ -132,7 +132,7 @@ public class RestOperations implements OperationsHandler {
     public Response consumeRecords(String topicName,
                                    RecordFilterParams params) {
 
-        var result = recordOperations.consumeRecords(topicName, params.getPartition(), params.getOffset(), params.getTimestamp(), params.getLimit(), params.getIncludeList());
+        var result = recordOperations.consumeRecords(topicName, params.getPartition(), params.getOffset(), params.getTimestamp(), params.getLimit(), params.getIncludeList(), params.getMaxValueLength());
         return Response.ok(result).build();
     }
 

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/model/Types.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/model/Types.java
@@ -1846,6 +1846,7 @@ public class Types {
         @QueryParam(PROP_LIMIT)
         @DefaultValue("20")
         @Parameter(description = "Limit the number of records fetched and returned")
+        @Positive
         Integer limit;
 
         @QueryParam(PROP_INCLUDE)

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/model/Types.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/model/Types.java
@@ -1827,6 +1827,7 @@ public class Types {
 
     public static class RecordFilterParams {
         public static final String PROP_LIMIT = "limit";
+        public static final String PROP_MAX_VALUE_LENGTH = "maxValueLength";
         public static final String PROP_INCLUDE = "include";
 
         @QueryParam(Record.PROP_PARTITION)
@@ -1856,6 +1857,13 @@ public class Types {
             explode = Explode.FALSE,
             schema = @Schema(implementation = RecordIncludedProperty[].class))
         String include;
+
+        @QueryParam(PROP_MAX_VALUE_LENGTH)
+        @Parameter(description = "Maximum length of string values returned in the response. "
+                + "Values with a length that exceeds this parameter will be truncated. When this parameter is not "
+                + "included in the request, the full string values will be returned.")
+        @Positive
+        Integer maxValueLength;
 
         @AssertTrue(message = "invalid timestamp")
         public boolean isTimestampValid() {
@@ -1916,6 +1924,14 @@ public class Types {
 
         public void setInclude(String include) {
             this.include = include;
+        }
+
+        public Integer getMaxValueLength() {
+            return maxValueLength;
+        }
+
+        public void setMaxValueLength(Integer maxValueLength) {
+            this.maxValueLength = maxValueLength;
         }
     }
 

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/model/Types.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/model/Types.java
@@ -1835,6 +1835,7 @@ public class Types {
 
         @QueryParam(Record.PROP_OFFSET)
         @Parameter(description = "Retrieve messages with an offset equal to or greater than this offset. If both `timestamp` and `offset` are requested, `timestamp` is given preference.")
+        @Min(0)
         Integer offset;
 
         @QueryParam(Record.PROP_TIMESTAMP)

--- a/kafka-admin/src/test/java/org/bf2/admin/kafka/admin/RecordOperationsTest.java
+++ b/kafka-admin/src/test/java/org/bf2/admin/kafka/admin/RecordOperationsTest.java
@@ -1,0 +1,92 @@
+package org.bf2.admin.kafka.admin;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RecordOperationsTest {
+
+    @ParameterizedTest
+    @CsvSource(nullValues = "null", value = {
+        "null",
+        "''",
+        "Valid value"
+    })
+    void testBytesToStringValid(String input) {
+        RecordOperations target = new RecordOperations();
+        String out = target.bytesToString(input != null ? input.getBytes() : null);
+        assertEquals(input, out);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "\uFFFE",
+        "\uFFFF",
+        "Valid until the end\uFFFF"
+    })
+    void testBytesToStringNoncharacters(String sequence) {
+        RecordOperations target = new RecordOperations();
+        String out = target.bytesToString(sequence.getBytes());
+        assertEquals(RecordOperations.BINARY_DATA_MESSAGE, out);
+    }
+
+    @Test
+    void testBytesToStringNoncharacterRange() {
+        for (char i = '\uFDD0'; i < '\uFDEF' + 1; i++) {
+            RecordOperations target = new RecordOperations();
+            String out = target.bytesToString(String.valueOf(i).getBytes());
+            assertEquals(RecordOperations.BINARY_DATA_MESSAGE, out);
+        }
+    }
+
+    @Test
+    void testBytesToStringUnmappable() throws UnsupportedEncodingException {
+        RecordOperations target = new RecordOperations();
+        String out = target.bytesToString("¬".getBytes("ISO-8859-1"));
+        assertEquals(RecordOperations.BINARY_DATA_MESSAGE, out);
+    }
+
+    @Test
+    void testBytesToStringUnmappableSequence() throws Exception {
+        RecordOperations target = new RecordOperations();
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (Writer writer = new OutputStreamWriter(bytes, "windows-1252")) {
+            writer.write("©");
+        }
+        String out = target.bytesToString(bytes.toByteArray());
+        assertEquals(RecordOperations.BINARY_DATA_MESSAGE, out);
+    }
+
+    @Test
+    void testBytesToStringInvalid() throws UnsupportedEncodingException {
+        RecordOperations target = new RecordOperations();
+        String out = target.bytesToString(new byte[] {
+            (byte) 0xC1
+        });
+        assertEquals(RecordOperations.BINARY_DATA_MESSAGE, out);
+    }
+
+    static int[] continuationRange() {
+        return IntStream.rangeClosed(0x80, 0xbf).toArray();
+    }
+
+    @ParameterizedTest
+    @MethodSource("continuationRange")
+    void testBytesToStringContinuationRange(int continuation) {
+        RecordOperations target = new RecordOperations();
+        String out = target.bytesToString(new byte[] {
+            (byte) continuation
+        });
+        assertEquals(RecordOperations.BINARY_DATA_MESSAGE, out);
+    }
+}

--- a/kafka-admin/src/test/java/org/bf2/admin/kafka/admin/RecordOperationsTest.java
+++ b/kafka-admin/src/test/java/org/bf2/admin/kafka/admin/RecordOperationsTest.java
@@ -24,7 +24,7 @@ class RecordOperationsTest {
     })
     void testBytesToStringValid(String input) {
         RecordOperations target = new RecordOperations();
-        String out = target.bytesToString(input != null ? input.getBytes() : null);
+        String out = target.bytesToString(input != null ? input.getBytes() : null, null);
         assertEquals(input, out);
     }
 
@@ -36,7 +36,7 @@ class RecordOperationsTest {
     })
     void testBytesToStringNoncharacters(String sequence) {
         RecordOperations target = new RecordOperations();
-        String out = target.bytesToString(sequence.getBytes());
+        String out = target.bytesToString(sequence.getBytes(), null);
         assertEquals(RecordOperations.BINARY_DATA_MESSAGE, out);
     }
 
@@ -44,7 +44,7 @@ class RecordOperationsTest {
     void testBytesToStringNoncharacterRange() {
         for (char i = '\uFDD0'; i < '\uFDEF' + 1; i++) {
             RecordOperations target = new RecordOperations();
-            String out = target.bytesToString(String.valueOf(i).getBytes());
+            String out = target.bytesToString(String.valueOf(i).getBytes(), null);
             assertEquals(RecordOperations.BINARY_DATA_MESSAGE, out);
         }
     }
@@ -52,7 +52,7 @@ class RecordOperationsTest {
     @Test
     void testBytesToStringUnmappable() throws UnsupportedEncodingException {
         RecordOperations target = new RecordOperations();
-        String out = target.bytesToString("¬".getBytes("ISO-8859-1"));
+        String out = target.bytesToString("¬".getBytes("ISO-8859-1"), null);
         assertEquals(RecordOperations.BINARY_DATA_MESSAGE, out);
     }
 
@@ -63,7 +63,7 @@ class RecordOperationsTest {
         try (Writer writer = new OutputStreamWriter(bytes, "windows-1252")) {
             writer.write("©");
         }
-        String out = target.bytesToString(bytes.toByteArray());
+        String out = target.bytesToString(bytes.toByteArray(), null);
         assertEquals(RecordOperations.BINARY_DATA_MESSAGE, out);
     }
 
@@ -72,7 +72,7 @@ class RecordOperationsTest {
         RecordOperations target = new RecordOperations();
         String out = target.bytesToString(new byte[] {
             (byte) 0xC1
-        });
+        }, null);
         assertEquals(RecordOperations.BINARY_DATA_MESSAGE, out);
     }
 
@@ -86,7 +86,7 @@ class RecordOperationsTest {
         RecordOperations target = new RecordOperations();
         String out = target.bytesToString(new byte[] {
             (byte) continuation
-        });
+        }, null);
         assertEquals(RecordOperations.BINARY_DATA_MESSAGE, out);
     }
 }

--- a/systemtests/src/main/java/org/bf2/admin/kafka/systemtest/utils/ClientsConfig.java
+++ b/systemtests/src/main/java/org/bf2/admin/kafka/systemtest/utils/ClientsConfig.java
@@ -7,6 +7,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.bf2.admin.kafka.admin.KafkaAdminConfigRetriever;
 import org.eclipse.microprofile.config.Config;
 
@@ -26,10 +27,15 @@ public class ClientsConfig {
     }
 
     public static Properties getProducerConfig(Config config) {
+        String serializer = StringSerializer.class.getName();
+        return getProducerConfig(config, serializer, serializer);
+    }
+
+    public static Properties getProducerConfig(Config config, String keySerializer, String valueSerializer) {
         Properties props = new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getValue(KafkaAdminConfigRetriever.BOOTSTRAP_SERVERS, String.class));
-        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer);
         props.put(ProducerConfig.ACKS_CONFIG, "all");
         return props;
     }


### PR DESCRIPTION
Separate commits for each task
MGDSTRM-8262 - Improve handling of non-string values, binary value detection
MGDSTRM-8290 - Support browsing latest messages when offset parameter not provided
MGDSTRM-8291 - Handle null header values, tolerate duplicate header keys
MGDSTRM-8292 - Optional param to limit length of message consumer values
