### PR TITLE
fix: add swagger ui config

### DIFF
--- a/kafka-admin/src/main/resources/application.properties
+++ b/kafka-admin/src/main/resources/application.properties
@@ -36,6 +36,11 @@ mp.openapi.scan.disable=false
 mp.openapi.filter=org.bf2.admin.kafka.admin.handlers.OASModelFilter
 quarkus.smallrye-openapi.info-version=${quarkus.application.version:0.0.1-SNAPSHOT}
 
+quarkus.swagger-ui.enable=true
+quarkus.swagger-ui.always-include=true
+quarkus.swagger-ui.title=Kafka Instance Admin
+quarkus.swagger-ui.theme=monokaig
+
 quarkus.log.category."org.apache.kafka".level=WARN
 
 kafka.admin.oauth.enabled=${quarkus.smallrye-jwt.enabled}

--- a/kafka-admin/src/main/resources/application.properties
+++ b/kafka-admin/src/main/resources/application.properties
@@ -39,7 +39,7 @@ quarkus.smallrye-openapi.info-version=${quarkus.application.version:0.0.1-SNAPSH
 quarkus.swagger-ui.enable=true
 quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.title=Kafka Instance Admin
-quarkus.swagger-ui.theme=monokaig
+quarkus.swagger-ui.theme=monokai
 
 quarkus.log.category."org.apache.kafka".level=WARN
 


### PR DESCRIPTION
Expose basic swagger ui for end users under `/swagger-ui` endpoint
![Screenshot 2022-06-07 at 17 37 38](https://user-images.githubusercontent.com/981838/172436122-70f7262c-63ec-4ed9-acc2-edc4c377a1d0.png)

