### PR TITLE
[MGDSTRM-6791] Adding code coverage for Admin Server

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -39,3 +39,35 @@ jobs:
         with:
           name: artifacts
           path: systemtests/target/failsafe-reports/
+  quality:
+    needs: [ integration ]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    name: quality
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow --tags --force
+      - uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+
+      - name: cache sonar
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: maven cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: sonar
+        env:
+          SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
+        run: mvn -B verify --file pom.xml sonar:sonar -Dsonar.projectKey=biswas-sri-kafka-admin-api -Dsonar.login=$SONAR_TOKEN

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -40,7 +40,6 @@ jobs:
           name: artifacts
           path: systemtests/target/failsafe-reports/
   quality:
-    needs: [ integration ]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     name: quality

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: "Integration tests"
         run: |
-          mvn verify -B --no-transfer-progress sonar:sonar -Dsonar.projectKey=biswas-sri-kafka-admin-api -Dsonar.login=$SONAR_TOKEN
+          mvn verify -B --no-transfer-progress sonar:sonar -Pcoverage -Dsonar.projectKey=biswas-sri-kafka-admin-api -Dsonar.login=$SONAR_TOKEN
 
       - name: Archive results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: "Integration tests"
         run: |
-          mvn verify -B --no-transfer-progress sonar:sonar -Pcoverage -Dsonar.projectKey=biswas-sri-kafka-admin-api -Dsonar.login=$SONAR_TOKEN
+          mvn verify -B --no-transfer-progress sonar:sonar -Pcoverage -Dsonar.organization=test-bf2-sonar -Dsonar.projectKey=biswassri_kafka-admin-api -Dsonar.login=$SONAR_TOKEN
 
       - name: Archive results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: "Integration tests"
         run: |
-          mvn verify -B --no-transfer-progress
+          mvn verify -B --no-transfer-progress sonar:sonar -Dsonar.projectKey=biswas-sri-kafka-admin-api -Dsonar.login=$SONAR_TOKEN
 
       - name: Archive results
         uses: actions/upload-artifact@v2
@@ -39,34 +39,3 @@ jobs:
         with:
           name: artifacts
           path: systemtests/target/failsafe-reports/
-  quality:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    name: quality
-
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow --tags --force
-      - uses: actions/setup-java@v1.4.3
-        with:
-          java-version: 11
-
-      - name: cache sonar
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: maven cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: sonar
-        env:
-          SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
-        run: mvn -B verify --file pom.xml sonar:sonar -Dsonar.projectKey=biswas-sri-kafka-admin-api -Dsonar.login=$SONAR_TOKEN

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -21,6 +21,13 @@ jobs:
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@v1
 
+      - name: Cache Sonar
+          uses: actions/cache@v1
+          with:
+            path: ~/.sonar/cache
+            key: ${{ runner.os }}-sonar
+            restore-keys: ${{ runner.os }}-sonar
+
       - name: Cache m2 repo
         uses: actions/cache@v1
         with:
@@ -30,8 +37,13 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: "Integration tests"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          SONAR_ORG: ${{secrets.SONAR_ORG}}
+          SONAR_PROJECT: ${{secrets.SONAR_PROJECT}}
+          SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
         run: |
-          mvn verify -B --no-transfer-progress sonar:sonar -Pcoverage -Dsonar.organization=test-bf2-sonar -Dsonar.projectKey=biswassri_kafka-admin-api -Dsonar.login=$SONAR_TOKEN
+          mvn verify -B --no-transfer-progress org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Pcoverage -Dsonar.organization=${SONAR_ORG} -Dsonar.projectKey=${SONAR_PROJECT} -Dsonar.login=${SONAR_TOKEN}
 
       - name: Archive results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -22,11 +22,11 @@ jobs:
         uses: docker-practice/actions-setup-docker@v1
 
       - name: Cache Sonar
-          uses: actions/cache@v1
-          with:
-            path: ~/.sonar/cache
-            key: ${{ runner.os }}-sonar
-            restore-keys: ${{ runner.os }}-sonar
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
 
       - name: Cache m2 repo
         uses: actions/cache@v1

--- a/kafka-admin/pom.xml
+++ b/kafka-admin/pom.xml
@@ -23,6 +23,48 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/kafka/admin/model/Types**</exclude>
+                            </excludes>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.01</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/kafka-admin/pom.xml
+++ b/kafka-admin/pom.xml
@@ -23,48 +23,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
-                <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>jacoco-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/kafka/admin/model/Types**</exclude>
-                            </excludes>
-                            <rules>
-                                <rule>
-                                    <element>PACKAGE</element>
-                                    <limits>
-                                        <limit>
-                                            <counter>LINE</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.01</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -150,6 +108,52 @@
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
             </properties>
+        </profile>
+        <profile>
+            <id>coverage</id>
+            <properties>
+                <argLine>@{jacocoArgLine}</argLine>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-report</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>jacoco-check</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes>
+                                        <exclude>**/kafka/admin/model/Types**</exclude>
+                                    </excludes>
+                                    <rules>
+                                        <rule>
+                                            <element>PACKAGE</element>
+                                            <limits>
+                                                <limit>
+                                                    <counter>LINE</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>0.01</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 

--- a/kafka-admin/src/test/java/org/bf2/admin/LoggingConfigWatcherTest.java
+++ b/kafka-admin/src/test/java/org/bf2/admin/LoggingConfigWatcherTest.java
@@ -69,7 +69,6 @@ class LoggingConfigWatcherTest {
         assertTrue(watcher.overriddenLoggers.isEmpty(), () -> "overriddenLoggers not empty: " + watcher.overriddenLoggers);
         assertEquals(originalLevelValue, context.getLogger(logger).getLevel());
     }
-
     @ParameterizedTest
     @CsvSource({
         "'',        quarkus.log.level",
@@ -86,7 +85,7 @@ class LoggingConfigWatcherTest {
 
             // Trigger a modification event
             writeString(override, String.format("%s=%s\nignored=anything\n", property, "DEBUG"));
-            return ws.poll(5, TimeUnit.SECONDS);
+            return ws.poll(15, TimeUnit.SECONDS);
         });
 
         assertTrue(dirExists);

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,14 @@
         <maven.checkstyle.version>3.1.2</maven.checkstyle.version>
         <spotbugs.version>4.0.3</spotbugs.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <version.jacoco.plugin>0.8.8</version.jacoco.plugin>
+
+        <!-- Sonar settings -->
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.organization>test-bf2-sonar</sonar.organization>
         <sonar.coverage.jacoco.xmlReportPaths>
-            ${project.basedir}/kafka-admin/target/site/jacoco/jacoco.xml,
-            ${project.basedir}/systemtests/target/site/jacoco/jacoco.xml
+            ${project.basedir}/../systemtests/target/site/jacoco-aggregate/jacoco.xml,
+            ${project.basedir}/systemtests/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
@@ -103,6 +108,27 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven.compiler.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${version.jacoco.plugin}</version>
+                    <configuration>
+                        <propertyName>jacocoArgLine</propertyName>
+                        <append>true</append>
+                        <excludes>
+                            <exclude>META-INF/**</exclude>
+                        </excludes>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                            <phase>generate-test-resources</phase>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,12 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
                         <id>default-report</id>
                         <goals>
                             <goal>report</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,45 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.01</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${maven.checkstyle.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,12 @@
                 <version>0.8.8</version>
                 <executions>
                     <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
                         <id>default-report</id>
                         <goals>
                             <goal>report</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -177,18 +177,7 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.8</version>
-                <configuration>
-                    <excludes>
-                        <exclude>systemtests/**</exclude>
-                    </excludes>
-                </configuration>
                 <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
                     <execution>
                         <id>default-report</id>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,9 @@
                             <goal>check</goal>
                         </goals>
                         <configuration>
+                            <excludes>
+                                <exclude>**/systemtest/**</exclude>
+                            </excludes>
                             <rules>
                                 <rule>
                                     <element>PACKAGE</element>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,9 @@
         <maven.checkstyle.version>3.1.2</maven.checkstyle.version>
         <spotbugs.version>4.0.3</spotbugs.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.basedir}/kafka-admin/target/site/jacoco/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <scm>
@@ -169,48 +172,6 @@
                                 <ignoredDependency>org.bouncycastle:bcprov-jdk15on</ignoredDependency>
                                 <ignoredDependency>com.jayway.jsonpath:json-path</ignoredDependency>
                             </ignoredDependencies>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
-                <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>jacoco-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/systemtest/**</exclude>
-                            </excludes>
-                            <rules>
-                                <rule>
-                                    <element>PACKAGE</element>
-                                    <limits>
-                                        <limit>
-                                            <counter>LINE</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.01</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
                 <version>0.8.6</version>
                 <configuration>
                     <excludes>
-                        <exclude>systemtests</exclude>
+                        <exclude>systemtests/**</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.6</version>
+                <configuration>
+                    <excludes>
+                        <exclude>systemtests</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,8 @@
         <spotbugs.version>4.0.3</spotbugs.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <sonar.coverage.jacoco.xmlReportPaths>
-            ${project.basedir}/kafka-admin/target/site/jacoco/jacoco.xml
+            ${project.basedir}/kafka-admin/target/site/jacoco/jacoco.xml,
+            ${project.basedir}/systemtests/target/site/jacoco/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -176,19 +176,13 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.6</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>systemtests/**</exclude>
                     </excludes>
                 </configuration>
                 <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
                     <execution>
                         <id>default-report</id>
                         <goals>

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -19,25 +19,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
-                <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.0.0</version>
@@ -184,6 +165,29 @@
         </dependency>
     </dependencies>
     <profiles>
+        <profile>
+            <id>coverage</id>
+            <properties>
+                <argLine>@{jacocoArgLine}</argLine>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jacoco-report-aggregate</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report-aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>default</id>
             <properties>

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -14,6 +14,7 @@
         <!-- System test image dependencies -->
         <keycloak.image>quay.io/keycloak/keycloak:14.0.0</keycloak.image>
         <strimzi-kafka.tag>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</strimzi-kafka.tag>
+        <basepom.check.skip-coverage>true</basepom.check.skip-coverage>
     </properties>
 
     <build>

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -19,6 +19,25 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.0.0</version>

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -14,7 +14,7 @@
         <!-- System test image dependencies -->
         <keycloak.image>quay.io/keycloak/keycloak:14.0.0</keycloak.image>
         <strimzi-kafka.tag>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</strimzi-kafka.tag>
-        <basepom.check.skip-coverage>true</basepom.check.skip-coverage>
+        <jacoco.skip>true</jacoco.skip>
     </properties>
 
     <build>

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -14,7 +14,6 @@
         <!-- System test image dependencies -->
         <keycloak.image>quay.io/keycloak/keycloak:14.0.0</keycloak.image>
         <strimzi-kafka.tag>quay.io/strimzi/kafka:0.26.0-kafka-3.0.0</strimzi-kafka.tag>
-        <jacoco.skip>true</jacoco.skip>
     </properties>
 
     <build>

--- a/systemtests/src/main/resources/keycloak-import/realms/authz-realm.json
+++ b/systemtests/src/main/resources/keycloak-import/realms/authz-realm.json
@@ -1,6 +1,6 @@
 {
   "realm": "kafka-authz",
-  "accessTokenLifespan": 30,
+  "accessTokenLifespan": 45,
   "ssoSessionIdleTimeout": 864000,
   "ssoSessionMaxLifespan": 864000,
   "enabled": true,

--- a/systemtests/src/main/resources/keycloak-import/realms/authz-realm.json
+++ b/systemtests/src/main/resources/keycloak-import/realms/authz-realm.json
@@ -1,6 +1,6 @@
 {
   "realm": "kafka-authz",
-  "accessTokenLifespan": 45,
+  "accessTokenLifespan": 60,
   "ssoSessionIdleTimeout": 864000,
   "ssoSessionMaxLifespan": 864000,
   "enabled": true,


### PR DESCRIPTION
Generating coverage reports using Jacoco and adding sonar cloud coverage to visualize the coverage analysis. 

Sonar cloud link :https://sonarcloud.io/summary/new_code?id=biswassri_kafka-admin-api&branch=sonar-integration (The link will change into a bf2 sonar cloud link once completed)
