### PR TITLE
Skip OpenAPI event dispatch for repository forks

### DIFF
--- a/.github/workflows/openapi_update.yaml
+++ b/.github/workflows/openapi_update.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   dispatch:
+    if: ${{ github.repository == 'bf2fc6cc711aee1a0c2a/kafka-admin-api' }}
     env:
       APP_SERVICES_CI_TOKEN: "${{ secrets.APP_SERVICES_CI_TOKEN }}"
     strategy:


### PR DESCRIPTION
Job currently fails in any fork without a valid `APP_SERVICES_CI_TOKEN`. Only the primary repo should notify the SDK repositories of OpenAPI updates.