### PR TITLE
MGDX-284: now push openapi changes to core sdk aswell

### DIFF
--- a/.github/workflows/openapi_update.yaml
+++ b/.github/workflows/openapi_update.yaml
@@ -13,7 +13,7 @@ jobs:
       APP_SERVICES_CI_TOKEN: "${{ secrets.APP_SERVICES_CI_TOKEN }}"
     strategy:
       matrix:
-        repo: ["redhat-developer/app-services-sdk-go", "redhat-developer/app-services-sdk-js", "redhat-developer/app-services-sdk-java"]
+        repo: ["redhat-developer/app-services-sdk-go", "redhat-developer/app-services-sdk-js", "redhat-developer/app-services-sdk-java", "redhat-developer/app-services-sdk-core"]
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch


### PR DESCRIPTION
## Description
This pr enables changes to the openapi spec to be push to the core SDK repo aswell as the other SDKs.

## Jjra
https://issues.redhat.com/browse/MGDX-284