### PR TITLE
Remove illegally overwritten fields in the OpenApi spec

### DIFF
--- a/kafka-admin/.openapi/kafka-admin-rest.yaml
+++ b/kafka-admin/.openapi/kafka-admin-rest.yaml
@@ -1013,6 +1013,8 @@ components:
       allOf:
       - $ref: '#/components/schemas/List'
       - description: A page of ACL binding entries
+        required:
+        - items
         type: object
         properties:
           items:
@@ -1194,6 +1196,8 @@ components:
       allOf:
       - $ref: '#/components/schemas/ListDeprecated'
       - description: A list of consumer groups
+        required:
+        - items
         type: object
         properties:
           items:
@@ -1269,7 +1273,9 @@ components:
     ConsumerGroupResetOffsetResult:
       allOf:
       - $ref: '#/components/schemas/List'
-      - type: object
+      - required:
+        - items
+        type: object
         properties:
           items:
             type: array
@@ -1337,6 +1343,8 @@ components:
       allOf:
       - $ref: '#/components/schemas/List'
       - description: List of errors
+        required:
+        - items
         type: object
         properties:
           items:
@@ -1349,16 +1357,11 @@ components:
             type: integer
     List:
       required:
-      - items
       - total
       type: object
       properties:
         kind:
           type: string
-        items:
-          type: array
-          items:
-            type: object
         total:
           format: int32
           description: Total number of entries in the full result set
@@ -1532,6 +1535,8 @@ components:
       allOf:
       - $ref: '#/components/schemas/List'
       - description: A page of records consumed from a topic
+        required:
+        - items
         type: object
         properties:
           items:
@@ -1642,6 +1647,8 @@ components:
       allOf:
       - $ref: '#/components/schemas/ListDeprecated'
       - description: A list of topics.
+        required:
+        - items
         type: object
         properties:
           items:

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/model/Types.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/model/Types.java
@@ -893,6 +893,7 @@ public class Types {
         private String kind;
 
         @NotNull
+        @Schema(hidden = true)
         private List<T> items;
 
         @NotNull
@@ -1040,6 +1041,7 @@ public class Types {
     }
 
     @Schema(description = "A list of consumer groups",
+            requiredProperties = "items",
             properties = {
                 @SchemaProperty(name = "items", implementation = ConsumerGroup[].class)
             },
@@ -1102,6 +1104,7 @@ public class Types {
 
     @Schema(name = "TopicsList",
             description = "A list of topics.",
+            requiredProperties = "items",
             properties = {
                 @SchemaProperty(name = "items", implementation = Topic[].class)
             },
@@ -1139,6 +1142,7 @@ public class Types {
     }
 
     @Schema(
+        requiredProperties = "items",
         properties = {
             @SchemaProperty(name = "items", implementation = TopicPartitionResetResult[].class)
         },
@@ -1152,6 +1156,7 @@ public class Types {
     @Schema(
         name = "AclBindingListPage",
         description = "A page of ACL binding entries",
+        requiredProperties = "items",
         properties = {
             @SchemaProperty(name = "items", implementation = AclBinding[].class)
         },
@@ -1844,6 +1849,7 @@ public class Types {
 
     @Schema(
         description = "List of errors",
+        requiredProperties = "items",
         properties = {
             @SchemaProperty(name = "items", implementation = Error[].class),
             @SchemaProperty(name = "total", implementation = Integer.class, description = "Total number of errors returned in this request")
@@ -1857,6 +1863,7 @@ public class Types {
 
     @Schema(
         description = "A page of records consumed from a topic",
+        requiredProperties = "items",
         properties = {
             @SchemaProperty(name = "items", implementation = Record[].class),
             @SchemaProperty(name = "total", implementation = Integer.class, description = "Total number of records returned in this request. This value does not indicate the total number of records in the topic."),


### PR DESCRIPTION
Hi!
I'm currently working on the SDKs and I found this illegal pattern used in the OpenAPI Spec.
According to [this issue](https://github.com/OAI/OpenAPI-Specification/issues/3069) overwriting of a property is undefined behavior.

The same pattern is being applied to [similar cases](https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1518).