### PR TITLE
Propagate 403 handling to the openapi spec

### DIFF
--- a/kafka-admin/.openapi/kafka-admin-rest.yaml
+++ b/kafka-admin/.openapi/kafka-admin-rest.yaml
@@ -7,7 +7,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
-  version: 0.13.1-SNAPSHOT
+  version: 0.14.1-SNAPSHOT
 servers:
 - url: /
   description: Kafka Admin REST API
@@ -92,6 +92,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/NotAuthorized'
+        "403":
+          $ref: '#/components/responses/Forbidden'
         "500":
           $ref: '#/components/responses/ServerError'
         "503":
@@ -124,6 +126,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/NotAuthorized'
+        "403":
+          $ref: '#/components/responses/Forbidden'
         "409":
           $ref: '#/components/responses/Conflict'
         "500":
@@ -462,6 +466,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/NotAuthorized'
+        "403":
+          $ref: '#/components/responses/Forbidden'
         "500":
           $ref: '#/components/responses/ServerError'
         "503":
@@ -920,6 +926,8 @@ paths:
                   value: "{}"
         "401":
           $ref: '#/components/responses/NotAuthorized'
+        "403":
+          $ref: '#/components/responses/Forbidden'
         "500":
           $ref: '#/components/responses/ServerError'
       security:

--- a/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/OperationsHandler.java
+++ b/kafka-admin/src/main/java/org/bf2/admin/kafka/admin/handlers/OperationsHandler.java
@@ -53,6 +53,7 @@ public interface OperationsHandler {
         responseDescription = "Topic created successfully.")
     @APIResponse(responseCode = "400", ref = "BadRequest")
     @APIResponse(responseCode = "401", ref = "NotAuthorized")
+    @APIResponse(responseCode = "403", ref = "Forbidden")
     @APIResponse(responseCode = "409", ref = "Conflict")
     @APIResponse(responseCode = "500", ref = "ServerError")
     @APIResponse(responseCode = "503", ref = "ServiceUnavailable")
@@ -144,6 +145,7 @@ public interface OperationsHandler {
         responseDescription = "List of topics matching the request query parameters. The topics returned are limited to those records the requestor is authorized to view.")
     @APIResponse(responseCode = "400", ref = "BadRequest")
     @APIResponse(responseCode = "401", ref = "NotAuthorized")
+    @APIResponse(responseCode = "403", ref = "Forbidden")
     @APIResponse(responseCode = "500", ref = "ServerError")
     @APIResponse(responseCode = "503", ref = "ServiceUnavailable")
     CompletionStage<Response> listTopics(@QueryParam("filter") String filter,
@@ -223,6 +225,7 @@ public interface OperationsHandler {
         responseDescription = "List of consumer groups matching the request parameters. The consumer groups returned are limited to those records the requestor is authorized to view.")
     @APIResponse(responseCode = "400", ref = "BadRequest")
     @APIResponse(responseCode = "401", ref = "NotAuthorized")
+    @APIResponse(responseCode = "403", ref = "Forbidden")
     @APIResponse(responseCode = "500", ref = "ServerError")
     @APIResponse(responseCode = "503", ref = "ServiceUnavailable")
     CompletionStage<Response> listGroups(@QueryParam("group-id-filter") String groupFilter,
@@ -326,6 +329,7 @@ public interface OperationsHandler {
         description = "Retrieve the resources and associated operations that may have ACLs configured.")
     @APIResponse(responseCode = "200", description = "Map of allowed resources and operations for ACL creation")
     @APIResponse(responseCode = "401", ref = "NotAuthorized")
+    @APIResponse(responseCode = "403", ref = "Forbidden")
     @APIResponse(responseCode = "500", ref = "ServerError")
     Response getAclResourceOperations();
 


### PR DESCRIPTION
We have noticed that more endpoints were throwing 403 responses.
Since the mapper for 403 is common I expanded the specification to keep 403 always into account.

This change is needed to generate better/nicer error-handling code in generated clients.